### PR TITLE
Introduce --once-only to support cron-style execution

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,5 @@
+use std::{sync::mpsc::Sender, thread::sleep, time::Duration};
+
 pub mod actions;
 pub mod errors;
 pub mod git;
@@ -5,3 +7,165 @@ pub mod opts;
 pub mod receiver;
 pub mod store;
 pub mod task;
+
+#[derive(Debug, PartialEq)]
+pub enum Progress {
+    Running,
+    Idle,
+}
+
+pub fn run_tasks<F, T>(
+    tasks: &mut [T],
+    mut persist: F,
+    tx: &Sender<receiver::ActionOutput>,
+    once_only: bool,
+    poll_interval: Duration,
+) -> Result<(), errors::GitOpsError>
+where
+    F: FnMut(&T) -> Result<(), errors::GitOpsError>,
+    T: task::Task,
+{
+    loop {
+        let res = progress_one_task(tasks, &mut persist, tx)?;
+        if (res == Progress::Idle) && once_only {
+            return Ok(());
+        }
+        sleep(poll_interval);
+    }
+}
+
+fn progress_one_task<F, T>(
+    tasks: &mut [T],
+    persist: &mut F,
+    tx: &Sender<receiver::ActionOutput>,
+) -> Result<Progress, errors::GitOpsError>
+where
+    F: FnMut(&T) -> Result<(), errors::GitOpsError>,
+    T: task::Task,
+{
+    if let Some(task) = tasks.iter_mut().find(|t| t.is_eligible()) {
+        let task_tx = tx.clone();
+        task.start(task_tx)?;
+        task.schedule_next();
+        persist(task)?;
+        return Ok(Progress::Running);
+    } else if let Some(task) = tasks.iter_mut().find(|t| t.is_finished()) {
+        match task.finalize() {
+            Ok(_) => persist(task)?,
+            Err(err) if err.is_fatal() => return Err(err),
+            Err(_) => (),
+        }
+        return Ok(Progress::Running);
+    } else if tasks.iter().any(|t| t.is_running()) {
+        return Ok(Progress::Running);
+    }
+    Ok(Progress::Idle)
+}
+
+#[cfg(test)]
+mod lib {
+    use std::cell::RefCell;
+    use std::sync::mpsc::Sender;
+
+    use crate::errors::GitOpsError;
+    use crate::receiver::ActionOutput;
+    use crate::task::{State, Task};
+
+    #[derive(Default)]
+    struct TestTask {
+        pub id: String,
+        pub status: RefCell<Option<bool>>,
+        pub eligible: RefCell<bool>,
+    }
+
+    impl TestTask {
+        pub fn new(id: String) -> Self {
+            Self {
+                id,
+                ..Default::default()
+            }
+        }
+        pub fn make_eligible(&self) {
+            *self.eligible.borrow_mut() = true;
+        }
+
+        pub fn run(&self) {
+            *self.eligible.borrow_mut() = false;
+            *self.status.borrow_mut() = Some(true);
+        }
+
+        pub fn complete(&self) {
+            let mut v = self.status.borrow_mut();
+            if v.is_some() {
+                *v = Some(false);
+            }
+        }
+    }
+
+    impl Task for TestTask {
+        fn id(&self) -> String {
+            self.id.clone()
+        }
+
+        fn is_eligible(&self) -> bool {
+            self.status.borrow().is_none() && *self.eligible.borrow()
+        }
+
+        fn is_running(&self) -> bool {
+            self.status.borrow().is_some_and(|s| s)
+        }
+
+        fn is_finished(&self) -> bool {
+            self.status.borrow().is_some_and(|s| !s)
+        }
+
+        fn schedule_next(&mut self) {}
+
+        fn start(&mut self, _: Sender<ActionOutput>) -> Result<(), GitOpsError> {
+            assert!(*self.eligible.borrow());
+            assert!(self.status.borrow().is_none());
+            self.run();
+            Ok(())
+        }
+
+        fn finalize(&mut self) -> Result<(), GitOpsError> {
+            assert!(!*self.eligible.borrow());
+            assert!(self.status.borrow().is_some());
+            *self.status.borrow_mut() = None;
+            Ok(())
+        }
+
+        fn state(&self) -> State {
+            todo!("Not needed")
+        }
+
+        fn set_state(&mut self, _: State) {
+            todo!("Not needed")
+        }
+    }
+
+    #[test]
+    fn dont_start_ineligible_task() {
+        let mut tasks = vec![TestTask::new("id-1".to_owned())];
+        let (tx, _) = std::sync::mpsc::channel();
+        let mut persist = |_t: &TestTask| Ok(());
+        let progress = super::progress_one_task(&mut tasks[..], &mut persist, &tx).unwrap();
+        assert!(progress == super::Progress::Idle);
+        assert!(!tasks[0].is_running());
+    }
+
+    #[test]
+    fn run_eligible_task() {
+        let mut tasks = vec![TestTask::new("id-1".to_owned())];
+        let (tx, _) = std::sync::mpsc::channel();
+        let mut persist = |_t: &TestTask| Ok(());
+        tasks[0].make_eligible();
+        let progress = super::progress_one_task(&mut tasks[..], &mut persist, &tx).unwrap();
+        assert!(progress == super::Progress::Running);
+        assert!(tasks[0].is_running());
+        tasks[0].complete();
+        let progress = super::progress_one_task(&mut tasks[..], &mut persist, &tx).unwrap();
+        assert!(progress == super::Progress::Running);
+        assert!(!tasks[0].is_eligible());
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,49 +3,14 @@
 use clap::Parser;
 use kitops::errors::GitOpsError;
 use kitops::opts::{load_store, load_tasks, CliOptions};
-use kitops::receiver::{logging_receiver, ActionOutput};
+use kitops::receiver::logging_receiver;
+use kitops::run_tasks;
 use kitops::store::Store;
-use kitops::task::Task;
-use std::{
-    collections::HashSet,
-    convert::Infallible,
-    sync::mpsc::{channel, Sender},
-    thread::{sleep, spawn},
-    time::Duration,
-};
+use kitops::task::{GitTask, Task};
+use std::time::Duration;
+use std::{collections::HashSet, sync::mpsc::channel, thread::spawn};
 
-fn run<F>(
-    tasks: &mut [Task],
-    mut persist: F,
-    tx: &Sender<ActionOutput>,
-) -> Result<Infallible, GitOpsError>
-where
-    F: FnMut(&Task) -> Result<(), GitOpsError>,
-{
-    loop {
-        if let Some(task) = tasks.iter_mut().find(|t| t.is_eligible()) {
-            let task_tx = tx.clone();
-            task.start(task_tx)?;
-            task.schedule_next();
-            persist(task)?;
-            continue;
-        }
-        if let Some(task) = tasks.iter_mut().find(|t| t.is_finished()) {
-            match task.take_result() {
-                Ok(new_sha) => {
-                    task.processed_sha(new_sha);
-                    persist(task)?;
-                }
-                Err(err) if err.is_fatal() => return Err(err),
-                Err(_) => (),
-            }
-            continue;
-        }
-        sleep(Duration::from_secs(1));
-    }
-}
-
-fn main() -> Result<Infallible, GitOpsError> {
+fn main() -> Result<(), GitOpsError> {
     let mut opts = CliOptions::parse();
     if let Some(ref dir) = opts.repo_dir {
         if !dir.exists() {
@@ -65,12 +30,18 @@ fn main() -> Result<Infallible, GitOpsError> {
     });
     let mut tasks = load_tasks(&opts)?;
     let mut store = load_store(&opts)?;
-    let task_ids = tasks.iter().map(Task::id).collect::<HashSet<_>>();
+    let task_ids = tasks.iter().map(GitTask::id).collect::<HashSet<_>>();
     store.retain(task_ids);
     for task in &mut tasks {
         if let Some(s) = store.get(&task.id()) {
-            task.state = s.clone();
+            task.set_state(s.clone());
         }
     }
-    run(&mut tasks, |t: &Task| store.persist(t), &tx)
+    run_tasks(
+        &mut tasks[..],
+        |t: &GitTask| store.persist(t),
+        &tx,
+        opts.once_only,
+        Duration::from_secs(1),
+    )
 }

--- a/src/store.rs
+++ b/src/store.rs
@@ -12,7 +12,9 @@ use crate::{
 pub trait Store {
     fn get(&self, id: &str) -> Option<&State>;
     fn retain(&mut self, task_ids: HashSet<String>);
-    fn persist(&mut self, task: &Task) -> Result<(), GitOpsError>;
+    fn persist<T>(&mut self, task: &T) -> Result<(), GitOpsError>
+    where
+        T: Task;
 }
 
 #[derive(Debug, Default)]
@@ -45,8 +47,11 @@ impl Store for FileStore {
         self.state.retain(|id, _| task_ids.contains(id));
     }
 
-    fn persist(&mut self, task: &Task) -> Result<(), GitOpsError> {
-        self.state.insert(task.id(), task.state.clone());
+    fn persist<T>(&mut self, task: &T) -> Result<(), GitOpsError>
+    where
+        T: Task,
+    {
+        self.state.insert(task.id(), task.state());
         let file = File::create(&self.path).map_err(GitOpsError::SavingState)?;
         serde_yaml::to_writer(file, &self.state).map_err(GitOpsError::SerdeState)
     }


### PR DESCRIPTION
This PR allows kitops to be run through cron. It runs until actions for all eligible tasks have completed and then exits.

The PR also refactors the projects so we can test the logic that progresses tasks without having to contend with the pesky infinite loop.

The task running tests suggests that some part of the Task interface should actually be shared between task implementation; the current implementation actually duplicates a bit of the task state logic. This is left for a future PR.