### PR TITLE
Ensures gix errors abort watchdog for speedy exit

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ The plan forward, roughly in falling priority:
 - [x] --poll-once to check all repos that are due, then exit
 - [ ] verify azdo support - Byron/gitoxide#1025
 - [ ] Reasonable timeout duration entry (i.e. not serde default secs/nanos)
-- [ ] Errors in scoped blocks should cancel, not wait for watchdog to reach deadline
+- [x] Errors in scoped blocks should cancel, not wait for watchdog to reach deadline
 - [ ] allow configuring notification actions
 - [ ] specialized notification action to update github status
 - [ ] new git sha and branch name in action env vars

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,7 @@ pub mod opts;
 pub mod receiver;
 pub mod store;
 pub mod task;
+pub(crate) mod utils;
 
 #[derive(Debug, PartialEq)]
 pub enum Progress {

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,0 +1,44 @@
+use std::ops::Deref;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::thread::sleep;
+use std::time::{Duration, Instant};
+
+#[cfg(test)]
+const POLL_INTERVAL: Duration = Duration::from_millis(10);
+#[cfg(not(test))]
+const POLL_INTERVAL: Duration = Duration::from_millis(500);
+
+pub struct Watchdog {
+    deadline: Instant,
+    cancellation: AtomicBool,
+}
+
+impl Watchdog {
+    pub fn new(deadline: Instant) -> Self {
+        Self {
+            deadline,
+            cancellation: AtomicBool::new(false),
+        }
+    }
+
+    pub fn runner(&self) -> impl FnOnce() + '_ {
+        || {
+            while Instant::now() < self.deadline && !self.cancellation.load(Ordering::Relaxed) {
+                sleep(POLL_INTERVAL);
+            }
+            self.cancellation.store(true, Ordering::Relaxed);
+        }
+    }
+
+    pub fn cancel(&self) {
+        self.cancellation.store(true, Ordering::Relaxed);
+    }
+}
+
+impl Deref for Watchdog {
+    type Target = AtomicBool;
+
+    fn deref(&self) -> &Self::Target {
+        &self.cancellation
+    }
+}


### PR DESCRIPTION
Previously, because of "?", the watchdog was cancelled only on success.

Also refactor the watchdog into its own thing for better readability.