### PR TITLE
Interval and timeout are parsed with humantime

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1291,6 +1291,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "86cce260d758a9aa3d7c4b99d55c815a540f8a37514ba6046ab6be402a157cb0"
 
 [[package]]
+name = "humantime"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
+
+[[package]]
 name = "hyper"
 version = "0.14.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1436,6 +1442,7 @@ version = "0.1.0"
 dependencies = [
  "clap",
  "gix",
+ "humantime",
  "serde",
  "serde_yaml",
  "tempfile",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ edition = "2021"
 [dependencies]
 clap = { version = "4.1.4", features = ["derive"] }
 gix = { version = "0.51.0", features = ["default", "blocking-network-client", "blocking-http-transport-reqwest-native-tls", "serde"] }
+humantime = "2.1.0"
 serde = { version = "1.0.152", features = ["derive"] }
 serde_yaml = "0.9.17"
 tempfile = "3.3.0"

--- a/README.md
+++ b/README.md
@@ -10,11 +10,12 @@ The plan forward, roughly in falling priority:
 
 - [x] --poll-once to check all repos that are due, then exit
 - [ ] verify azdo support - Byron/gitoxide#1025
-- [ ] Reasonable timeout duration entry (i.e. not serde default secs/nanos)
+- [x] Reasonable timeout duration entry (i.e. not serde default secs/nanos)
 - [x] Errors in scoped blocks should cancel, not wait for watchdog to reach deadline
 - [ ] allow configuring notification actions
 - [ ] specialized notification action to update github status
 - [ ] new git sha and branch name in action env vars
+- [ ] changed task config should override state loaded from disk
 - [ ] docker packaging
 - [ ] readme with design and deployment options
 - [ ] intelligent gitconfig handling

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ The plan forward, roughly in falling priority:
 - [x] Reasonable timeout duration entry (i.e. not serde default secs/nanos)
 - [x] Errors in scoped blocks should cancel, not wait for watchdog to reach deadline
 - [ ] allow configuring notification actions
+- [ ] proper options validation (e.g. config-file xor url/action)
 - [ ] specialized notification action to update github status
 - [ ] new git sha and branch name in action env vars
 - [ ] changed task config should override state loaded from disk

--- a/src/task.rs
+++ b/src/task.rs
@@ -7,7 +7,7 @@ use std::{
 };
 
 use gix::{hash::Kind, ObjectId, Url};
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Deserializer, Serialize};
 
 use crate::{
     actions::{run_action, Action},
@@ -30,14 +30,14 @@ pub trait Task {
 }
 
 pub struct GitTask {
-    config: GitOpsConfig,
+    config: GitTaskConfig,
     repo_dir: PathBuf,
     pub state: State,
     worker: Option<JoinHandle<Result<ObjectId, GitOpsError>>>,
 }
 
 impl GitTask {
-    pub fn from_config(config: GitOpsConfig, opts: &CliOptions) -> Self {
+    pub fn from_config(config: GitTaskConfig, opts: &CliOptions) -> Self {
         let repo_dir = opts
             .repo_dir
             .as_ref()
@@ -138,24 +138,38 @@ impl Default for State {
     }
 }
 
+fn human_readable_duration<'de, D>(deserializer: D) -> Result<Duration, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let s: String = Deserialize::deserialize(deserializer)?;
+    humantime::parse_duration(&s).map_err(serde::de::Error::custom)
+}
+
 #[derive(Clone, Deserialize)]
-pub struct GitOpsConfig {
+pub struct GitTaskConfig {
     name: String,
     git: GitConfig,
     actions: Vec<Action>,
-    #[serde(default = "GitOpsConfig::default_interval")]
+    #[serde(
+        default = "GitTaskConfig::default_interval",
+        deserialize_with = "human_readable_duration"
+    )]
     interval: Duration,
-    #[serde(default = "GitOpsConfig::default_timeout")]
+    #[serde(
+        default = "GitTaskConfig::default_timeout",
+        deserialize_with = "human_readable_duration"
+    )]
     timeout: Duration,
 }
 
-impl GitOpsConfig {
+impl GitTaskConfig {
     pub fn add_action(&mut self, action: Action) {
         self.actions.push(action);
     }
 }
 
-impl TryFrom<&CliOptions> for GitOpsConfig {
+impl TryFrom<&CliOptions> for GitTaskConfig {
     type Error = GitOpsError;
 
     fn try_from(opts: &CliOptions) -> Result<Self, Self::Error> {
@@ -164,22 +178,39 @@ impl TryFrom<&CliOptions> for GitOpsConfig {
             name: url.path.to_string(),
             git: TryFrom::try_from(opts)?,
             actions: Vec::new(),
-            interval: opts
-                .interval
-                .map_or(GitOpsConfig::default_interval(), Duration::from_secs_f32),
-            timeout: opts
-                .timeout
-                .map_or(GitOpsConfig::default_timeout(), Duration::from_secs_f32),
+            interval: opts.interval.unwrap_or(Self::default_interval()),
+            timeout: opts.timeout.unwrap_or(Self::default_timeout()),
         })
     }
 }
 
-impl GitOpsConfig {
+impl GitTaskConfig {
     pub fn default_interval() -> Duration {
         Duration::from_secs(60)
     }
 
     pub fn default_timeout() -> Duration {
         Duration::from_secs(3600)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use super::GitTaskConfig;
+
+    #[test]
+    fn parse_gittaskconfig() {
+        let raw_config = r#"name: testo
+git:
+  url: https://github.com/bittrance/kitops
+timeout: 3s
+interval: 1m 2s
+actions: []
+      "#;
+        let config = serde_yaml::from_str::<GitTaskConfig>(raw_config).unwrap();
+        assert_eq!(config.timeout, Duration::from_secs(3));
+        assert_eq!(config.interval, Duration::from_secs(62));
     }
 }


### PR DESCRIPTION
Both cli options and task config now uses the ubiquitous `<n><u>` format, e.g. `30s` or `5m 30s`.