### PR TITLE
Access private GitHub repos using GitHub app credentials

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,15 @@
 version = 3
 
 [[package]]
+name = "addr2line"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a30b2e23b9e17a9f90641c7ab1549cd9b44f296d3ccbf309d2863cfe398a0cb"
+dependencies = [
+ "gimli",
+]
+
+[[package]]
 name = "adler"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10,14 +19,15 @@ checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
 name = "ahash"
-version = "0.8.3"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c99f64d1e06488f620f932677e24bc6e2897582980441ae90a671415bd7ec2f"
+checksum = "91429305e9f0a25f6205c5b8e0d2db09e0708a7a6df0f42212bb56c32c8ac97a"
 dependencies = [
  "cfg-if",
  "getrandom",
  "once_cell",
  "version_check",
+ "zerocopy",
 ]
 
 [[package]]
@@ -27,6 +37,54 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2969dcb958b36655471fc61f7e416fa76033bdd4bfed0678d8fee1e2d07a1f0"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "anstream"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ab91ebe16eb252986481c5b62f6098f3b698a45e34b5b98200cf20dd2484a44"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7079075b41f533b8c61d2a4d073c4676e1f8b249ff94a393b0595db304e0dd87"
+
+[[package]]
+name = "anstyle-parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "317b9a89c1868f5ea6ff1d9539a69f45dffc21ce321ac1fd1160dfa48c8e2140"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ca11d4be1bab0c8bc8734a9aa7bf4ee8316d462a08c6ac5052f888fef5b494b"
+dependencies = [
+ "windows-sys",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0699d10d2f4d628a98ee7b57b289abbc98ff3bad977cb3152709d4bf2330628"
+dependencies = [
+ "anstyle",
+ "windows-sys",
 ]
 
 [[package]]
@@ -43,15 +101,15 @@ checksum = "bddcadddf5e9015d310179a59bb28c4d4b9920ad0f11e8e14dbadf654890c9a6"
 
 [[package]]
 name = "arrayvec"
-version = "0.7.2"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8da52d66c7071e2e3fa2a1e5c6d088fec47b593032b254f5e980de8ea54454d6"
+checksum = "96d30a06541fbafbc7f82ed10c06164cfbd2c401138f6addd8404629c4b16711"
 
 [[package]]
 name = "async-compression"
-version = "0.4.3"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb42b2197bf15ccb092b62c74515dbd8b86d0effd934795f6687c93b6e679a2c"
+checksum = "bc2d0cfb2a7388d34f590e76686704c494ed7aaceed62ee1ba35cbf363abc2a5"
 dependencies = [
  "flate2",
  "futures-core",
@@ -67,6 +125,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
+name = "backtrace"
+version = "0.3.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2089b7e3f35b9dd2d0ed921ead4f6d318c27680d4a5bd167b3ee120edb105837"
+dependencies = [
+ "addr2line",
+ "cc",
+ "cfg-if",
+ "libc",
+ "miniz_oxide",
+ "object",
+ "rustc-demangle",
+]
+
+[[package]]
 name = "base16ct"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -74,9 +147,9 @@ checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
 
 [[package]]
 name = "base64"
-version = "0.21.0"
+version = "0.21.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4a4ddaa51a5bc52a6948f74c06d20aaaddb71924eab79b8c97a8c556e942d6a"
+checksum = "35636a1494ede3b646cc98f74f8e62c773a38a659ebc777a2cf26b9b74171df9"
 
 [[package]]
 name = "base64ct"
@@ -98,9 +171,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.4.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4682ae6287fcf752ecaabbfcc7b6f9b72aa33933dc23a554d853aea8eea8635"
+checksum = "327762f6e5a765692301e5bb513e0d9fef63be86bbc14528052b1cd3e6f03e07"
 dependencies = [
  "serde",
 ]
@@ -116,9 +189,9 @@ dependencies = [
 
 [[package]]
 name = "bstr"
-version = "1.6.0"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6798148dccfbff0fae41c7574d2fa8f1ef3492fba0face179de5d8d447d67b05"
+checksum = "542f33a8835a0884b006a0c3df3dadd99c0c3f296ed26c2fdc8028e01ad6230c"
 dependencies = [
  "memchr",
  "regex-automata",
@@ -136,33 +209,36 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.12.0"
+version = "3.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d261e256854913907f67ed06efbc3338dfe6179796deefc1ff763fc1aee5535"
+checksum = "7f30e7476521f6f8af1a1c4c0b8cc94f0bee37d91763d0ca2665f299b6cd8aec"
 
 [[package]]
 name = "byteorder"
-version = "1.4.3"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.4.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89b2fd2a0dcf38d7971e2194b6b6eebab45ae01067456a7fd93d5547a61b70be"
+checksum = "a2bd12c1caf447e69cd4528f47f94d203fd2582878ecb9e9465484c4148a8223"
 
 [[package]]
 name = "bytesize"
-version = "1.1.0"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c58ec36aac5066d5ca17df51b3e70279f5670a72102f5752cb7e7c856adfc70"
+checksum = "a3e368af43e418a04d52505cf3dbc23dda4e3407ae2fa99fd0e4f308ce546acc"
 
 [[package]]
 name = "cc"
-version = "1.0.79"
+version = "1.0.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50d30906286121d95be3d479533b458f87493b30a4b5f79a607db8f5d11aa91f"
+checksum = "f1174fb0b6ec23863f8b971027804a42614e347eafb0a95bf0b12cdae21fc4d0"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "cfg-if"
@@ -172,40 +248,43 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "clap"
-version = "4.1.4"
+version = "4.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f13b9c79b5d1dd500d20ef541215a6423c75829ef43117e1b4d17fd8af0b5d76"
+checksum = "2275f18819641850fa26c89acc84d465c1bf91ce57bc2748b28c420473352f64"
 dependencies = [
- "bitflags 1.3.2",
+ "clap_builder",
  "clap_derive",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07cdf1b148b25c1e1f7a42225e30a0d99a615cd4637eae7365548dd4529b95bc"
+dependencies = [
+ "anstream",
+ "anstyle",
  "clap_lex",
- "is-terminal",
- "once_cell",
  "strsim",
- "termcolor",
 ]
 
 [[package]]
 name = "clap_derive"
-version = "4.1.0"
+version = "4.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "684a277d672e91966334af371f1a7b5833f9aa00b07c84e92fbce95e00208ce8"
+checksum = "cf9804afaaf59a91e75b022a30fb7229a7901f60c755489cc61c9b423b836442"
 dependencies = [
  "heck",
- "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 1.0.107",
+ "syn 2.0.39",
 ]
 
 [[package]]
 name = "clap_lex"
-version = "0.3.1"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "783fe232adfca04f90f56201b26d79682d4cd2625e0bc7290b95123afe558ade"
-dependencies = [
- "os_str_bytes",
-]
+checksum = "702fc72eb24e5a1e48ce58027a675bc24edd52096d5397d4aea7c6dd9eca0bd1"
 
 [[package]]
 name = "clru"
@@ -215,15 +294,21 @@ checksum = "b8191fa7302e03607ff0e237d4246cc043ff5b3cb9409d995172ba3bea16b807"
 
 [[package]]
 name = "coarsetime"
-version = "0.1.28"
+version = "0.1.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99280f81a35511dda7d44f7c943491b41d3ac6fd0b54aea92498bec8612a2423"
+checksum = "71367d3385c716342014ad17e3d19f7788ae514885a1f4c24f500260fb365e1a"
 dependencies = [
  "libc",
  "once_cell",
  "wasi",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "colorchoice"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
 
 [[package]]
 name = "const-oid"
@@ -243,15 +328,15 @@ dependencies = [
 
 [[package]]
 name = "core-foundation-sys"
-version = "0.8.3"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5827cebf4670468b8772dd191856768aedcb1b0278a04f989f7766351917b9dc"
+checksum = "e496a50fda8aacccc86d7529e2c1e0892dbd0f898a6b5645b5561b89c3210efa"
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.9"
+version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a17b76ff3a4162b0b27f354a0c87015ddad39d35f9c0c36607a3bdd175dde1f1"
+checksum = "ce420fe07aecd3e67c5f910618fe65e94158f6dcc0adf44e00d69ce2bdfe0fd0"
 dependencies = [
  "libc",
 ]
@@ -281,9 +366,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-channel"
-version = "0.5.6"
+version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2dd04ddaf88237dc3b8d8f9a3c1004b506b54b3313403944054d23c0870c521"
+checksum = "a33c2bf77f2df06183c3aa30d1e96c0695a313d4f9c453cc3762a6db39f99200"
 dependencies = [
  "cfg-if",
  "crossbeam-utils",
@@ -291,9 +376,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-deque"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "715e8152b692bba2d374b53d4875445368fdf21a94751410af607a5ac677d1fc"
+checksum = "ce6fd6f855243022dcecf8702fef0c297d4338e226845fe067f6341ad9fa0cef"
 dependencies = [
  "cfg-if",
  "crossbeam-epoch",
@@ -302,9 +387,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.13"
+version = "0.9.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01a9af1f4c2ef74bb8aa1f7e19706bc72d03598c8a570bb5de72243c7a9d9d5a"
+checksum = "ae211234986c545741a7dc064309f67ee1e5ad243d0e48335adc0484d960bcc7"
 dependencies = [
  "autocfg",
  "cfg-if",
@@ -325,18 +410,18 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.14"
+version = "0.8.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fb766fa798726286dbbb842f174001dab8abc7b627a1dd86e0b7222a95d929f"
+checksum = "5a22b2d63d4d1dc0b7f1b6b2747dd0088008a9be28b6ddf0b1e7d335e3037294"
 dependencies = [
  "cfg-if",
 ]
 
 [[package]]
 name = "crypto-bigint"
-version = "0.5.3"
+version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "740fe28e594155f10cfc383984cbefd529d7396050557148f79cb0f621204124"
+checksum = "28f85c3514d2a6e64160359b45a3918c3b4178bcbf4ae5d03ab2d02e521c479a"
 dependencies = [
  "generic-array",
  "rand_core",
@@ -384,9 +469,12 @@ dependencies = [
 
 [[package]]
 name = "deranged"
-version = "0.3.7"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7684a49fb1af197853ef7b2ee694bc1f5b4179556f1e5710e1760c5db6f5e929"
+checksum = "0f32d04922c60427da6f9fef14d042d9edddef64cb9d4ce0d64d0685fbeb1fd3"
+dependencies = [
+ "powerfmt",
+]
 
 [[package]]
 name = "digest"
@@ -408,15 +496,15 @@ checksum = "56ce8c6da7551ec6c462cbaf3bfbc75131ebbfa1c944aeaa9dab51ca1c5f0c3b"
 
 [[package]]
 name = "ecdsa"
-version = "0.16.8"
+version = "0.16.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4b1e0c257a9e9f25f90ff76d7a68360ed497ee519c8e428d1825ef0000799d4"
+checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
 dependencies = [
  "der 0.7.8",
  "digest",
  "elliptic-curve",
  "rfc6979",
- "signature 2.1.0",
+ "signature 2.2.0",
  "spki 0.7.2",
 ]
 
@@ -432,15 +520,15 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.8.1"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fcaabb2fef8c910e7f4c7ce9f67a1283a1715879a7c230ca9d6d1ae31f16d91"
+checksum = "a26ae43d7bcc3b814de94796a5e736d4029efb0ee900c12e2d54c993ad1a1e07"
 
 [[package]]
 name = "elliptic-curve"
-version = "0.13.5"
+version = "0.13.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "968405c8fdc9b3bf4df0a6638858cc0b52462836ab6b1c87377785dd09cf1c0b"
+checksum = "e9775b22bc152ad86a0cf23f0f348b884b26add12bf741e7ffc4d4ab2ab4d205"
 dependencies = [
  "base16ct",
  "crypto-bigint",
@@ -459,43 +547,27 @@ dependencies = [
 
 [[package]]
 name = "encoding_rs"
-version = "0.8.32"
+version = "0.8.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "071a31f4ee85403370b58aca746f01041ede6f0da2730960ad001edc2b71b394"
+checksum = "7268b386296a025e474d5140678f75d6de9493ae55a5d709eeb9dd08149945e1"
 dependencies = [
  "cfg-if",
 ]
 
 [[package]]
-name = "errno"
-version = "0.2.8"
+name = "equivalent"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f639046355ee4f37944e44f60642c6f3a7efa3cf6b78c78a0d989a8ce6c396a1"
-dependencies = [
- "errno-dragonfly",
- "libc",
- "winapi",
-]
+checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
 name = "errno"
-version = "0.3.1"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bcfec3a70f97c962c307b2d2c56e358cf1d00b558d74262b5f929ee8cc7e73a"
+checksum = "f258a7194e7f7c2a7837a8913aeab7fd8c383457034fa20ce4dd3dcb813e8eb8"
 dependencies = [
- "errno-dragonfly",
  "libc",
- "windows-sys 0.48.0",
-]
-
-[[package]]
-name = "errno-dragonfly"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa68f1b12764fab894d2755d2518754e71b4fd80ecfb822714a1206c2aab39bf"
-dependencies = [
- "cc",
- "libc",
+ "windows-sys",
 ]
 
 [[package]]
@@ -509,18 +581,9 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
-version = "1.9.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e51093e27b0797c359783294ca4f0a911c270184cb10f85783b118614a1501be"
-dependencies = [
- "instant",
-]
-
-[[package]]
-name = "fastrand"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6999dc1837253364c2ebb0704ba97994bd874e8f195d665c50b7548f6ea92764"
+checksum = "25cbce373ec4653f1a01a31e8a5e5ec0c622dc27ff9c4e6606eefef5cbbed4a5"
 
 [[package]]
 name = "ff"
@@ -534,21 +597,21 @@ dependencies = [
 
 [[package]]
 name = "filetime"
-version = "0.2.19"
+version = "0.2.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e884668cd0c7480504233e951174ddc3b382f7c2666e3b7310b5c4e7b0c37f9"
+checksum = "d4029edd3e734da6fe05b6cd7bd2960760a616bd2ddd0d59a0124746d6272af0"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall 0.2.16",
- "windows-sys 0.42.0",
+ "redox_syscall 0.3.5",
+ "windows-sys",
 ]
 
 [[package]]
 name = "flate2"
-version = "1.0.25"
+version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8a2db397cb1c8772f31494cb8917e48cd1e64f0fa7efac59fbd741a0a8ce841"
+checksum = "46303f565772937ffe1d394a4fac6f411c6013172fadde9dcdb1e147a086940e"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
@@ -577,51 +640,51 @@ checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "form_urlencoded"
-version = "1.1.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9c384f161156f5260c24a097c56119f9be8c798586aecc13afbcbe7b7e26bf8"
+checksum = "a62bc1cf6f830c2ec14a513a9fb124d0a213a629668a4186f329db21fe045652"
 dependencies = [
  "percent-encoding",
 ]
 
 [[package]]
 name = "futures-channel"
-version = "0.3.26"
+version = "0.3.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e5317663a9089767a1ec00a487df42e0ca174b61b4483213ac24448e4664df5"
+checksum = "ff4dd66668b557604244583e3e1e1eada8c5c2e96a6d0d6653ede395b78bbacb"
 dependencies = [
  "futures-core",
 ]
 
 [[package]]
 name = "futures-core"
-version = "0.3.26"
+version = "0.3.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec90ff4d0fe1f57d600049061dc6bb68ed03c7d2fbd697274c41805dcb3f8608"
+checksum = "eb1d22c66e66d9d72e1758f0bd7d4fd0bee04cad842ee34587d68c07e45d088c"
 
 [[package]]
 name = "futures-io"
-version = "0.3.26"
+version = "0.3.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfb8371b6fb2aeb2d280374607aeabfc99d95c72edfe51692e42d3d7f0d08531"
+checksum = "8bf34a163b5c4c52d0478a4d757da8fb65cabef42ba90515efee0f6f9fa45aaa"
 
 [[package]]
 name = "futures-sink"
-version = "0.3.26"
+version = "0.3.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f310820bb3e8cfd46c80db4d7fb8353e15dfff853a127158425f31e0be6c8364"
+checksum = "e36d3378ee38c2a36ad710c5d30c2911d752cb941c00c72dbabfb786a7970817"
 
 [[package]]
 name = "futures-task"
-version = "0.3.26"
+version = "0.3.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcf79a1bf610b10f42aea489289c5a2c478a786509693b80cd39c44ccd936366"
+checksum = "efd193069b0ddadc69c46389b740bbccdd97203899b48d09c5f7969591d6bae2"
 
 [[package]]
 name = "futures-util"
-version = "0.3.26"
+version = "0.3.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c1d6de3acfef38d2be4b1f543f553131788603495be83da675e180c8d6b7bd1"
+checksum = "a19526d624e703a3179b3d322efec918b6246ea0fa51d41124525f00f1cc8104"
 dependencies = [
  "futures-core",
  "futures-io",
@@ -645,9 +708,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.8"
+version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c05aeb6a22b8f62540c194aac980f2115af067bfe15a0734d7277a768d396b31"
+checksum = "fe9006bed769170c11f845cf00c7c1e9092aeb3f268e007c3e760ac68008070f"
 dependencies = [
  "cfg-if",
  "libc",
@@ -655,10 +718,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "gimli"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fb8d784f27acf97159b40fc4db5ecd8aa23b9ad5ef69cdd136d3bc80665f0c0"
+
+[[package]]
 name = "gix"
 version = "0.55.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "002667cd1ebb789313d0d0afe3d23b2821cf3b0e91605095f0e6d8751f0ceeea"
+source = "git+https://github.com/Byron/gitoxide?rev=2b80d842#2b80d8424196088d4ccc36914c87e320e4416ea1"
 dependencies = [
  "gix-actor",
  "gix-archive",
@@ -719,8 +787,7 @@ dependencies = [
 [[package]]
 name = "gix-actor"
 version = "0.28.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "948a5f9e43559d16faf583694f1c742eb401ce24ce8e6f2238caedea7486433c"
+source = "git+https://github.com/Byron/gitoxide?rev=2b80d842#2b80d8424196088d4ccc36914c87e320e4416ea1"
 dependencies = [
  "bstr",
  "btoi",
@@ -734,8 +801,7 @@ dependencies = [
 [[package]]
 name = "gix-archive"
 version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "909f8417346ebae6a8ca4e947966541a30a1eaac0d67c816f735cba03f0ff09d"
+source = "git+https://github.com/Byron/gitoxide?rev=2b80d842#2b80d8424196088d4ccc36914c87e320e4416ea1"
 dependencies = [
  "bstr",
  "gix-date",
@@ -747,8 +813,7 @@ dependencies = [
 [[package]]
 name = "gix-attributes"
 version = "0.20.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dca120f0c6562d2d7cae467f2466e576d9f7f189beec2af2e026145107c729e2"
+source = "git+https://github.com/Byron/gitoxide?rev=2b80d842#2b80d8424196088d4ccc36914c87e320e4416ea1"
 dependencies = [
  "bstr",
  "gix-glob",
@@ -765,8 +830,7 @@ dependencies = [
 [[package]]
 name = "gix-bitmap"
 version = "0.2.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ccab4bc576844ddb51b78d81b4a42d73e6229660fa614dfc3d3999c874d1959"
+source = "git+https://github.com/Byron/gitoxide?rev=2b80d842#2b80d8424196088d4ccc36914c87e320e4416ea1"
 dependencies = [
  "thiserror",
 ]
@@ -774,8 +838,7 @@ dependencies = [
 [[package]]
 name = "gix-chunk"
 version = "0.4.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b42ea64420f7994000130328f3c7a2038f639120518870436d31b8bde704493"
+source = "git+https://github.com/Byron/gitoxide?rev=2b80d842#2b80d8424196088d4ccc36914c87e320e4416ea1"
 dependencies = [
  "thiserror",
 ]
@@ -783,17 +846,18 @@ dependencies = [
 [[package]]
 name = "gix-command"
 version = "0.2.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c576cfbf577f72c097b5f88aedea502cd62952bdc1fb3adcab4531d5525a4c7"
+source = "git+https://github.com/Byron/gitoxide?rev=2b80d842#2b80d8424196088d4ccc36914c87e320e4416ea1"
 dependencies = [
  "bstr",
+ "gix-path",
+ "gix-trace",
+ "shell-words",
 ]
 
 [[package]]
 name = "gix-commitgraph"
 version = "0.22.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e8bc78b1a6328fa6d8b3a53b6c73997af37fd6bfc1d6c49f149e63bda5cbb36"
+source = "git+https://github.com/Byron/gitoxide?rev=2b80d842#2b80d8424196088d4ccc36914c87e320e4416ea1"
 dependencies = [
  "bstr",
  "gix-chunk",
@@ -807,8 +871,7 @@ dependencies = [
 [[package]]
 name = "gix-config"
 version = "0.31.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5cae98c6b4c66c09379bc35274b172587d6b0ac369a416c39128ad8c6454f9bb"
+source = "git+https://github.com/Byron/gitoxide?rev=2b80d842#2b80d8424196088d4ccc36914c87e320e4416ea1"
 dependencies = [
  "bstr",
  "gix-config-value",
@@ -828,10 +891,9 @@ dependencies = [
 [[package]]
 name = "gix-config-value"
 version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea7505b97f4d8e7933e29735a568ba2f86d8de466669d9f0e8321384f9972f47"
+source = "git+https://github.com/Byron/gitoxide?rev=2b80d842#2b80d8424196088d4ccc36914c87e320e4416ea1"
 dependencies = [
- "bitflags 2.4.0",
+ "bitflags 2.4.1",
  "bstr",
  "gix-path",
  "libc",
@@ -841,8 +903,7 @@ dependencies = [
 [[package]]
 name = "gix-credentials"
 version = "0.21.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c5c5d74069b842a1861e581027ac6b7ad9ff66f5911c89b9f45484d7ebda6a4"
+source = "git+https://github.com/Byron/gitoxide?rev=2b80d842#2b80d8424196088d4ccc36914c87e320e4416ea1"
 dependencies = [
  "bstr",
  "gix-command",
@@ -850,6 +911,7 @@ dependencies = [
  "gix-path",
  "gix-prompt",
  "gix-sec",
+ "gix-trace",
  "gix-url",
  "serde",
  "thiserror",
@@ -858,8 +920,7 @@ dependencies = [
 [[package]]
 name = "gix-date"
 version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc7df669639582dc7c02737642f76890b03b5544e141caba68a7d6b4eb551e0d"
+source = "git+https://github.com/Byron/gitoxide?rev=2b80d842#2b80d8424196088d4ccc36914c87e320e4416ea1"
 dependencies = [
  "bstr",
  "itoa",
@@ -871,9 +932,9 @@ dependencies = [
 [[package]]
 name = "gix-diff"
 version = "0.37.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "931394f69fb8c9ed6afc0aae3487bd869e936339bcc13ed8884472af072e0554"
+source = "git+https://github.com/Byron/gitoxide?rev=2b80d842#2b80d8424196088d4ccc36914c87e320e4416ea1"
 dependencies = [
+ "bstr",
  "gix-hash",
  "gix-object",
  "imara-diff",
@@ -883,8 +944,7 @@ dependencies = [
 [[package]]
 name = "gix-discover"
 version = "0.26.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a45d5cf0321178883e38705ab2b098f625d609a7d4c391b33ac952eff2c490f2"
+source = "git+https://github.com/Byron/gitoxide?rev=2b80d842#2b80d8424196088d4ccc36914c87e320e4416ea1"
 dependencies = [
  "bstr",
  "dunce",
@@ -898,8 +958,7 @@ dependencies = [
 [[package]]
 name = "gix-features"
 version = "0.36.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51f4365ba17c4f218d7fd9ec102b8d2d3cb0ca200a835e81151ace7778aec827"
+source = "git+https://github.com/Byron/gitoxide?rev=2b80d842#2b80d8424196088d4ccc36914c87e320e4416ea1"
 dependencies = [
  "bytes",
  "bytesize",
@@ -921,8 +980,7 @@ dependencies = [
 [[package]]
 name = "gix-filter"
 version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92f674d3fdb6b1987b04521ec9a5b7be8650671f2c4bbd17c3c81e2a364242ff"
+source = "git+https://github.com/Byron/gitoxide?rev=2b80d842#2b80d8424196088d4ccc36914c87e320e4416ea1"
 dependencies = [
  "bstr",
  "encoding_rs",
@@ -941,8 +999,7 @@ dependencies = [
 [[package]]
 name = "gix-fs"
 version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8cd171c0cae97cd0dc57e7b4601cb1ebf596450e263ef3c02be9107272c877bd"
+source = "git+https://github.com/Byron/gitoxide?rev=2b80d842#2b80d8424196088d4ccc36914c87e320e4416ea1"
 dependencies = [
  "gix-features",
 ]
@@ -950,10 +1007,9 @@ dependencies = [
 [[package]]
 name = "gix-glob"
 version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fac08925dbc14d414bd02eb45ffb4cecd912d1fce3883f867bd0103c192d3e4"
+source = "git+https://github.com/Byron/gitoxide?rev=2b80d842#2b80d8424196088d4ccc36914c87e320e4416ea1"
 dependencies = [
- "bitflags 2.4.0",
+ "bitflags 2.4.1",
  "bstr",
  "gix-features",
  "gix-path",
@@ -963,8 +1019,7 @@ dependencies = [
 [[package]]
 name = "gix-hash"
 version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1884c7b41ea0875217c1be9ce91322f90bde433e91d374d0e1276073a51ccc60"
+source = "git+https://github.com/Byron/gitoxide?rev=2b80d842#2b80d8424196088d4ccc36914c87e320e4416ea1"
 dependencies = [
  "faster-hex",
  "serde",
@@ -974,19 +1029,17 @@ dependencies = [
 [[package]]
 name = "gix-hashtable"
 version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "409268480841ad008e81c17ca5a293393fbf9f2b6c2f85b8ab9de1f0c5176a16"
+source = "git+https://github.com/Byron/gitoxide?rev=2b80d842#2b80d8424196088d4ccc36914c87e320e4416ea1"
 dependencies = [
  "gix-hash",
- "hashbrown 0.14.0",
+ "hashbrown 0.14.2",
  "parking_lot",
 ]
 
 [[package]]
 name = "gix-ignore"
 version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e73c07763a8005ae02cb5cf83040729cea9bb70c7cef68ec6c24159904c499a"
+source = "git+https://github.com/Byron/gitoxide?rev=2b80d842#2b80d8424196088d4ccc36914c87e320e4416ea1"
 dependencies = [
  "bstr",
  "gix-glob",
@@ -998,10 +1051,9 @@ dependencies = [
 [[package]]
 name = "gix-index"
 version = "0.26.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c83a4fcc121b2f2e109088f677f89f85e7a8ebf39e8e6659c0ae54d4283b1650"
+source = "git+https://github.com/Byron/gitoxide?rev=2b80d842#2b80d8424196088d4ccc36914c87e320e4416ea1"
 dependencies = [
- "bitflags 2.4.0",
+ "bitflags 2.4.1",
  "bstr",
  "btoi",
  "filetime",
@@ -1013,7 +1065,9 @@ dependencies = [
  "gix-object",
  "gix-traverse",
  "itoa",
+ "libc",
  "memmap2",
+ "rustix",
  "serde",
  "smallvec",
  "thiserror",
@@ -1022,8 +1076,7 @@ dependencies = [
 [[package]]
 name = "gix-lock"
 version = "11.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4feb1dcd304fe384ddc22edba9dd56a42b0800032de6537728cea2f033a4f37"
+source = "git+https://github.com/Byron/gitoxide?rev=2b80d842#2b80d8424196088d4ccc36914c87e320e4416ea1"
 dependencies = [
  "gix-tempfile",
  "gix-utils",
@@ -1033,19 +1086,17 @@ dependencies = [
 [[package]]
 name = "gix-macros"
 version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d8acb5ee668d55f0f2d19a320a3f9ef67a6999ad483e11135abcc2464ed18b6"
+source = "git+https://github.com/Byron/gitoxide?rev=2b80d842#2b80d8424196088d4ccc36914c87e320e4416ea1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.29",
+ "syn 2.0.39",
 ]
 
 [[package]]
 name = "gix-mailmap"
 version = "0.20.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "496141bc97ca2074401dfd3049a958554ab5a80c7f00a9dcfb41d29a7396f9e2"
+source = "git+https://github.com/Byron/gitoxide?rev=2b80d842#2b80d8424196088d4ccc36914c87e320e4416ea1"
 dependencies = [
  "bstr",
  "gix-actor",
@@ -1057,10 +1108,9 @@ dependencies = [
 [[package]]
 name = "gix-negotiate"
 version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a5cdcf491ecc9ce39dcc227216c540355fe0024ae7c38e94557752ca5ebb67f"
+source = "git+https://github.com/Byron/gitoxide?rev=2b80d842#2b80d8424196088d4ccc36914c87e320e4416ea1"
 dependencies = [
- "bitflags 2.4.0",
+ "bitflags 2.4.1",
  "gix-commitgraph",
  "gix-date",
  "gix-hash",
@@ -1073,8 +1123,7 @@ dependencies = [
 [[package]]
 name = "gix-object"
 version = "0.38.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "740f2a44267f58770a1cb3a3d01d14e67b089c7136c48d4bddbb3cfd2bf86a51"
+source = "git+https://github.com/Byron/gitoxide?rev=2b80d842#2b80d8424196088d4ccc36914c87e320e4416ea1"
 dependencies = [
  "bstr",
  "btoi",
@@ -1093,8 +1142,7 @@ dependencies = [
 [[package]]
 name = "gix-odb"
 version = "0.54.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8630b56cb80d8fa684d383dad006a66401ee8314e12fbf0e566ddad8c115143b"
+source = "git+https://github.com/Byron/gitoxide?rev=2b80d842#2b80d8424196088d4ccc36914c87e320e4416ea1"
 dependencies = [
  "arc-swap",
  "gix-date",
@@ -1113,8 +1161,7 @@ dependencies = [
 [[package]]
 name = "gix-pack"
 version = "0.44.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1431ba2e30deff1405920693d54ab231c88d7c240dd6ccc936ee223d8f8697c3"
+source = "git+https://github.com/Byron/gitoxide?rev=2b80d842#2b80d8424196088d4ccc36914c87e320e4416ea1"
 dependencies = [
  "clru",
  "gix-chunk",
@@ -1135,30 +1182,29 @@ dependencies = [
 [[package]]
 name = "gix-packetline"
 version = "0.16.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a8384b1e964151aff0d5632dd9b191059d07dff358b96bd940f1b452600d7ab"
+source = "git+https://github.com/Byron/gitoxide?rev=2b80d842#2b80d8424196088d4ccc36914c87e320e4416ea1"
 dependencies = [
  "bstr",
  "faster-hex",
+ "gix-trace",
  "thiserror",
 ]
 
 [[package]]
 name = "gix-packetline-blocking"
 version = "0.16.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d8395f7501c84d6a1fe902035fdfd8cd86d89e2dd6be0200ec1a72fd3c92d39"
+source = "git+https://github.com/Byron/gitoxide?rev=2b80d842#2b80d8424196088d4ccc36914c87e320e4416ea1"
 dependencies = [
  "bstr",
  "faster-hex",
+ "gix-trace",
  "thiserror",
 ]
 
 [[package]]
 name = "gix-path"
 version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a1d370115171e3ae03c5c6d4f7d096f2981a40ddccb98dfd704c773530ba73b"
+source = "git+https://github.com/Byron/gitoxide?rev=2b80d842#2b80d8424196088d4ccc36914c87e320e4416ea1"
 dependencies = [
  "bstr",
  "gix-trace",
@@ -1170,10 +1216,9 @@ dependencies = [
 [[package]]
 name = "gix-pathspec"
 version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9cc7194fdcf43b4a1ccfa13ffae1d79f83beb4becff7761d88dd99faeafe625"
+source = "git+https://github.com/Byron/gitoxide?rev=2b80d842#2b80d8424196088d4ccc36914c87e320e4416ea1"
 dependencies = [
- "bitflags 2.4.0",
+ "bitflags 2.4.1",
  "bstr",
  "gix-attributes",
  "gix-config-value",
@@ -1185,21 +1230,19 @@ dependencies = [
 [[package]]
 name = "gix-prompt"
 version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c9a913769516f5e9d937afac206fb76428e3d7238e538845842887fda584678"
+source = "git+https://github.com/Byron/gitoxide?rev=2b80d842#2b80d8424196088d4ccc36914c87e320e4416ea1"
 dependencies = [
  "gix-command",
  "gix-config-value",
  "parking_lot",
- "rustix 0.38.8",
+ "rustix",
  "thiserror",
 ]
 
 [[package]]
 name = "gix-protocol"
 version = "0.41.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "391e3feabdfa5f90dad6673ce59e3291ac28901b2ff248d86c5a7fbde0391e0e"
+source = "git+https://github.com/Byron/gitoxide?rev=2b80d842#2b80d8424196088d4ccc36914c87e320e4416ea1"
 dependencies = [
  "bstr",
  "btoi",
@@ -1217,8 +1260,7 @@ dependencies = [
 [[package]]
 name = "gix-quote"
 version = "0.4.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "475c86a97dd0127ba4465fbb239abac9ea10e68301470c9791a6dd5351cdc905"
+source = "git+https://github.com/Byron/gitoxide?rev=2b80d842#2b80d8424196088d4ccc36914c87e320e4416ea1"
 dependencies = [
  "bstr",
  "btoi",
@@ -1228,8 +1270,7 @@ dependencies = [
 [[package]]
 name = "gix-ref"
 version = "0.38.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ec2f6d07ac88d2fb8007ee3fa3e801856fb9d82e7366ec0ca332eb2c9d74a52"
+source = "git+https://github.com/Byron/gitoxide?rev=2b80d842#2b80d8424196088d4ccc36914c87e320e4416ea1"
 dependencies = [
  "gix-actor",
  "gix-date",
@@ -1250,8 +1291,7 @@ dependencies = [
 [[package]]
 name = "gix-refspec"
 version = "0.19.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ccb0974cc41dbdb43a180c7f67aa481e1c1e160fcfa8f4a55291fd1126c1a6e7"
+source = "git+https://github.com/Byron/gitoxide?rev=2b80d842#2b80d8424196088d4ccc36914c87e320e4416ea1"
 dependencies = [
  "bstr",
  "gix-hash",
@@ -1264,8 +1304,7 @@ dependencies = [
 [[package]]
 name = "gix-revision"
 version = "0.23.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ca97ac73459a7f3766aa4a5638a6e37d56d4c7962bc1986fbaf4883d0772588"
+source = "git+https://github.com/Byron/gitoxide?rev=2b80d842#2b80d8424196088d4ccc36914c87e320e4416ea1"
 dependencies = [
  "bstr",
  "gix-date",
@@ -1281,8 +1320,7 @@ dependencies = [
 [[package]]
 name = "gix-revwalk"
 version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a16d8c892e4cd676d86f0265bf9d40cefd73d8d94f86b213b8b77d50e77efae0"
+source = "git+https://github.com/Byron/gitoxide?rev=2b80d842#2b80d8424196088d4ccc36914c87e320e4416ea1"
 dependencies = [
  "gix-commitgraph",
  "gix-date",
@@ -1296,10 +1334,9 @@ dependencies = [
 [[package]]
 name = "gix-sec"
 version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92b9542ac025a8c02ed5d17b3fc031a111a384e859d0be3532ec4d58c40a0f28"
+source = "git+https://github.com/Byron/gitoxide?rev=2b80d842#2b80d8424196088d4ccc36914c87e320e4416ea1"
 dependencies = [
- "bitflags 2.4.0",
+ "bitflags 2.4.1",
  "gix-path",
  "libc",
  "serde",
@@ -1309,8 +1346,7 @@ dependencies = [
 [[package]]
 name = "gix-status"
 version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c54271ffb47bce5826be9214a3993d595c5285c1ec23c036d9b1012920f6ab0"
+source = "git+https://github.com/Byron/gitoxide?rev=2b80d842#2b80d8424196088d4ccc36914c87e320e4416ea1"
 dependencies = [
  "bstr",
  "filetime",
@@ -1321,7 +1357,6 @@ dependencies = [
  "gix-index",
  "gix-object",
  "gix-path",
- "gix-pathspec",
  "gix-worktree",
  "thiserror",
 ]
@@ -1329,8 +1364,7 @@ dependencies = [
 [[package]]
 name = "gix-submodule"
 version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bba78c8d12aa24370178453ec3a472ff08dfaa657d116229f57f2c9cd469a1c2"
+source = "git+https://github.com/Byron/gitoxide?rev=2b80d842#2b80d8424196088d4ccc36914c87e320e4416ea1"
 dependencies = [
  "bstr",
  "gix-config",
@@ -1344,8 +1378,7 @@ dependencies = [
 [[package]]
 name = "gix-tempfile"
 version = "11.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05cc2205cf10d99f70b96e04e16c55d4c7cf33efc151df1f793e29fd12a931f8"
+source = "git+https://github.com/Byron/gitoxide?rev=2b80d842#2b80d8424196088d4ccc36914c87e320e4416ea1"
 dependencies = [
  "gix-fs",
  "libc",
@@ -1359,14 +1392,12 @@ dependencies = [
 [[package]]
 name = "gix-trace"
 version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96b6d623a1152c3facb79067d6e2ecdae48130030cf27d6eb21109f13bd7b836"
+source = "git+https://github.com/Byron/gitoxide?rev=2b80d842#2b80d8424196088d4ccc36914c87e320e4416ea1"
 
 [[package]]
 name = "gix-transport"
 version = "0.38.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f209a93364e24f20319751bc11092272e2f3fe82bb72592b2822679cf5be752"
+source = "git+https://github.com/Byron/gitoxide?rev=2b80d842#2b80d8424196088d4ccc36914c87e320e4416ea1"
 dependencies = [
  "base64",
  "bstr",
@@ -1385,8 +1416,7 @@ dependencies = [
 [[package]]
 name = "gix-traverse"
 version = "0.34.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14d050ec7d4e1bb76abf0636cf4104fb915b70e54e3ced9a4427c999100ff38a"
+source = "git+https://github.com/Byron/gitoxide?rev=2b80d842#2b80d8424196088d4ccc36914c87e320e4416ea1"
 dependencies = [
  "gix-commitgraph",
  "gix-date",
@@ -1401,8 +1431,7 @@ dependencies = [
 [[package]]
 name = "gix-url"
 version = "0.25.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1b9ac8ed32ad45f9fc6c5f8c0be2ed911e544a5a19afd62d95d524ebaa95671"
+source = "git+https://github.com/Byron/gitoxide?rev=2b80d842#2b80d8424196088d4ccc36914c87e320e4416ea1"
 dependencies = [
  "bstr",
  "gix-features",
@@ -1416,17 +1445,15 @@ dependencies = [
 [[package]]
 name = "gix-utils"
 version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b85d89dc728613e26e0ed952a19583744e7f5240fcd4aa30d6c824ffd8b52f0f"
+source = "git+https://github.com/Byron/gitoxide?rev=2b80d842#2b80d8424196088d4ccc36914c87e320e4416ea1"
 dependencies = [
- "fastrand 2.0.0",
+ "fastrand",
 ]
 
 [[package]]
 name = "gix-validate"
 version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e05cab2b03a45b866156e052aa38619f4ece4adcb2f79978bfc249bc3b21b8c5"
+source = "git+https://github.com/Byron/gitoxide?rev=2b80d842#2b80d8424196088d4ccc36914c87e320e4416ea1"
 dependencies = [
  "bstr",
  "thiserror",
@@ -1435,8 +1462,7 @@ dependencies = [
 [[package]]
 name = "gix-worktree"
 version = "0.27.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddaf79e721dba64fe726a42f297a3c8ed42e55cdc0d81ca68452f2def3c2d7fd"
+source = "git+https://github.com/Byron/gitoxide?rev=2b80d842#2b80d8424196088d4ccc36914c87e320e4416ea1"
 dependencies = [
  "bstr",
  "gix-attributes",
@@ -1454,8 +1480,7 @@ dependencies = [
 [[package]]
 name = "gix-worktree-state"
 version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34a2fcccdcaf3c71c00a03df31c9aa459d444cabbec4ed9ca1fa64e43406bed4"
+source = "git+https://github.com/Byron/gitoxide?rev=2b80d842#2b80d8424196088d4ccc36914c87e320e4416ea1"
 dependencies = [
  "bstr",
  "gix-features",
@@ -1474,8 +1499,7 @@ dependencies = [
 [[package]]
 name = "gix-worktree-stream"
 version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee4b34b6f8c9347327682064627e3e72c1fc545849b6d4c183fdfa84af71af2c"
+source = "git+https://github.com/Byron/gitoxide?rev=2b80d842#2b80d8424196088d4ccc36914c87e320e4416ea1"
 dependencies = [
  "gix-attributes",
  "gix-features",
@@ -1502,9 +1526,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.3.15"
+version = "0.3.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f9f29bc9dda355256b2916cf526ab02ce0aeaaaf2bad60d65ef3f12f11dd0f4"
+checksum = "4d6250322ef6e60f93f9a2162799302cd6f68f79f6e5d85c8c16f14d1d958178"
 dependencies = [
  "bytes",
  "fnv",
@@ -1527,9 +1551,9 @@ checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hashbrown"
-version = "0.14.0"
+version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c6201b9ff9fd90a5a3bac2e56a830d0caa509576f0e503818ee82c181b3437a"
+checksum = "f93e7192158dbcda357bdec5fb5788eebf8bbac027f3f33e719d29135ae84156"
 
 [[package]]
 name = "heck"
@@ -1539,18 +1563,9 @@ checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
 name = "hermit-abi"
-version = "0.2.6"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee512640fe35acbfb4bb779db6f0d80704c2cacfa2e39b601ef3e3f47d1ae4c7"
-dependencies = [
- "libc",
-]
-
-[[package]]
-name = "hermit-abi"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "856b5cb0902c2b6d65d5fd97dfa30f9b70c7538e770b98eab5ed52d8db923e01"
+checksum = "d77f7ec81a6d05a3abb01ab6eb7590f6083d08449fe5a1c8b1e620283546ccb7"
 
 [[package]]
 name = "hkdf"
@@ -1596,18 +1611,18 @@ dependencies = [
 
 [[package]]
 name = "home"
-version = "0.5.4"
+version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "747309b4b440c06d57b0b25f2aee03ee9b5e5397d288c60e21fc709bb98a7408"
+checksum = "5444c27eef6923071f7ebcc33e3444508466a76f7a2b93da00ed6e19f30c1ddb"
 dependencies = [
- "winapi",
+ "windows-sys",
 ]
 
 [[package]]
 name = "http"
-version = "0.2.8"
+version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75f43d41e26995c17e71ee126451dd3941010b0514a81a9d11f3b341debc2399"
+checksum = "8947b1a6fad4393052c7ba1f4cd97bed3e953a95c79c92ad9b051a04611d9fbb"
 dependencies = [
  "bytes",
  "fnv",
@@ -1633,9 +1648,9 @@ checksum = "d897f394bad6a705d5f4104762e116a75639e470d80901eed05a860a95cb1904"
 
 [[package]]
 name = "httpdate"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4a1e36c821dbe04574f602848a19f742f4fb3c98d40449f11bcad18d6b17421"
+checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "human_format"
@@ -1651,9 +1666,9 @@ checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "hyper"
-version = "0.14.24"
+version = "0.14.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e011372fa0b68db8350aa7a248930ecc7839bf46d8485577d69f117a75f164c"
+checksum = "ffb1cfd654a8219eaef89881fdb3bb3b1cdc5fa75ded05d6933b2b382e395468"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -1666,7 +1681,7 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project-lite",
- "socket2",
+ "socket2 0.4.10",
  "tokio",
  "tower-service",
  "tracing",
@@ -1688,9 +1703,9 @@ dependencies = [
 
 [[package]]
 name = "idna"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e14ddfc70884202db2244c223200c204c2bda1bc6e0998d11b5e024d657209e6"
+checksum = "7d20d6b07bfbc108882d88ed8e37d39636dcc260e15e30c45e6ba089610b917c"
 dependencies = [
  "unicode-bidi",
  "unicode-normalization",
@@ -1708,21 +1723,12 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "1.9.2"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1885e79c1fc4b10f0e172c475f458b7f7b93061064d98c3293e98c5ba0c8b399"
+checksum = "d530e1a18b1cb4c484e6e34556a0d948706958449fca0cab753d649f2bce3d1f"
 dependencies = [
- "autocfg",
- "hashbrown 0.12.3",
-]
-
-[[package]]
-name = "instant"
-version = "0.1.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
-dependencies = [
- "cfg-if",
+ "equivalent",
+ "hashbrown 0.14.2",
 ]
 
 [[package]]
@@ -1736,45 +1742,22 @@ dependencies = [
 ]
 
 [[package]]
-name = "io-lifetimes"
-version = "1.0.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c66c74d2ae7e79a5a8f7ac924adbe38ee42a859c6539ad869eb51f0b52dc220"
-dependencies = [
- "hermit-abi 0.3.0",
- "libc",
- "windows-sys 0.48.0",
-]
-
-[[package]]
 name = "ipnet"
-version = "2.7.1"
+version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30e22bd8629359895450b59ea7a776c850561b96a3b1d31321c1949d9e6c9146"
-
-[[package]]
-name = "is-terminal"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22e18b0a45d56fe973d6db23972bf5bc46f988a4a2385deac9cc29572f09daef"
-dependencies = [
- "hermit-abi 0.3.0",
- "io-lifetimes",
- "rustix 0.36.8",
- "windows-sys 0.45.0",
-]
+checksum = "8f518f335dce6725a761382244631d86cf0ccb2863413590b31338feb467f9c3"
 
 [[package]]
 name = "itoa"
-version = "1.0.5"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fad582f4b9e86b6caa621cabeb0963332d92eea04729ab12892c2533951e6440"
+checksum = "af150ab688ff2122fcef229be89cb50dd66af9e01a4ff320cc137eecc9bacc38"
 
 [[package]]
 name = "js-sys"
-version = "0.3.61"
+version = "0.3.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "445dde2150c55e483f3d8416706b97ec8e8237c307e5b7b4b8dd15e6af2a0730"
+checksum = "54c0c35952f67de54bb584e9fd912b3023117cbafc0a77d8f3dee1fb5f572fe8"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -1791,9 +1774,9 @@ dependencies = [
 
 [[package]]
 name = "jwt-simple"
-version = "0.11.7"
+version = "0.11.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1283ac1b6399e76359084aede6e5edda7d8d3dac6725a9623c7c4f0e04bbd4df"
+checksum = "357892bb32159d763abdea50733fadcb9a8e1c319a9aa77592db8555d05af83e"
 dependencies = [
  "anyhow",
  "binstring",
@@ -1817,16 +1800,16 @@ dependencies = [
 
 [[package]]
 name = "k256"
-version = "0.13.1"
+version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cadb76004ed8e97623117f3df85b17aaa6626ab0b0831e6573f104df16cd1bcc"
+checksum = "3f01b677d82ef7a676aa37e099defd83a28e15687112cafdd112d60236b6115b"
 dependencies = [
  "cfg-if",
  "ecdsa",
  "elliptic-curve",
  "once_cell",
  "sha2",
- "signature 2.1.0",
+ "signature 2.2.0",
 ]
 
 [[package]]
@@ -1867,39 +1850,27 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.147"
+version = "0.2.150"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4668fb0ea861c1df094127ac5f1da3409a82116a4ba74fca2e58ef927159bb3"
+checksum = "89d92a4743f9a61002fae18374ed11e7973f530cb3a3255fb354818118b2203c"
 
 [[package]]
 name = "libm"
-version = "0.2.7"
+version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7012b1bbb0719e1097c47611d3898568c546d597c2e74d66f6087edd5233ff4"
+checksum = "4ec2a862134d2a7d32d7983ddcdd1c4923530833c9f2ea1a44fc5fa473989058"
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.1.4"
+version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f051f77a7c8e6957c0696eac88f26b0117e54f52d3fc682ab19397a8812846a4"
-
-[[package]]
-name = "linux-raw-sys"
-version = "0.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ece97ea872ece730aed82664c424eb4c8291e1ff2480247ccf7409044bc6479f"
-
-[[package]]
-name = "linux-raw-sys"
-version = "0.4.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57bcfdad1b858c2db7c38303a6d2ad4dfaf5eb53dfeb0910128b2c26d6158503"
+checksum = "969488b55f8ac402214f3f5fd243ebb7206cf82de60d3172994707a4bcc2b829"
 
 [[package]]
 name = "lock_api"
-version = "0.4.9"
+version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "435011366fe56583b16cf956f9df0095b405b82d76425bc8981c0e22e60ec4df"
+checksum = "3c168f8615b12bc01f9c17e2eb0cc07dcae1940121185446edc3744920e8ef45"
 dependencies = [
  "autocfg",
  "scopeguard",
@@ -1907,12 +1878,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.17"
+version = "0.4.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abb12e687cfb44aa40f41fc3978ef76448f9b6038cad6aef4259d3c095a2382e"
-dependencies = [
- "cfg-if",
-]
+checksum = "b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f"
 
 [[package]]
 name = "maybe-async"
@@ -1922,14 +1890,14 @@ checksum = "0f1b8c13cb1f814b634a96b2c725449fe7ed464a7b8781de8688be5ffbd3f305"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.107",
+ "syn 1.0.109",
 ]
 
 [[package]]
 name = "memchr"
-version = "2.5.0"
+version = "2.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
+checksum = "f665ee40bc4a3c5590afb1e9677db74a508659dfd71e126420da8274909a0167"
 
 [[package]]
 name = "memmap2"
@@ -1942,38 +1910,37 @@ dependencies = [
 
 [[package]]
 name = "memoffset"
-version = "0.7.1"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5de893c32cde5f383baa4c04c5d6dbdd735cfd4a794b0debdb2bb1b421da5ff4"
+checksum = "5a634b1c61a95585bd15607c6ab0c4e5b226e695ff2800ba0cdccddf208c406c"
 dependencies = [
  "autocfg",
 ]
 
 [[package]]
 name = "mime"
-version = "0.3.16"
+version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a60c7ce501c71e03a9c9c0d35b861413ae925bd979cc7a4e30d060069aaac8d"
+checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.6.2"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b275950c28b37e794e8c55d88aeb5e139d0ce23fdbbeda68f8d7174abdf9e8fa"
+checksum = "e7810e0be55b428ada41041c41f32c9f1a42817901b4ccf45fa3d4b6561e74c7"
 dependencies = [
  "adler",
 ]
 
 [[package]]
 name = "mio"
-version = "0.8.5"
+version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5d732bc30207a6423068df043e3d02e0735b155ad7ce1a6f76fe2baa5b158de"
+checksum = "3dce281c5e46beae905d4de1870d8b1509a9142b62eedf18b443b011ca8343d0"
 dependencies = [
  "libc",
- "log",
  "wasi",
- "windows-sys 0.42.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -2034,9 +2001,9 @@ dependencies = [
 
 [[package]]
 name = "num-traits"
-version = "0.2.15"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "578ede34cf02f8924ab9447f50c28075b4d3e5b269972345e7e0372b38c6cdcd"
+checksum = "39e3200413f237f41ab11ad6d161bc7239c84dcb631773ccd7de3dfe4b5c267c"
 dependencies = [
  "autocfg",
  "libm",
@@ -2044,11 +2011,11 @@ dependencies = [
 
 [[package]]
 name = "num_cpus"
-version = "1.15.0"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fac9e2da13b5eb447a6ce3d392f23a29d8694bff781bf03a16cd9ac8697593b"
+checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
 dependencies = [
- "hermit-abi 0.2.6",
+ "hermit-abi",
  "libc",
 ]
 
@@ -2062,18 +2029,27 @@ dependencies = [
 ]
 
 [[package]]
-name = "once_cell"
-version = "1.17.1"
+name = "object"
+version = "0.32.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7e5500299e16ebb147ae15a00a942af264cf3688f47923b8fc2cd5858f23ad3"
+checksum = "9cf5f9dd3933bd50a9e1f149ec995f39ae2c496d31fd772c1fd45ebc27e902b0"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "once_cell"
+version = "1.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
 
 [[package]]
 name = "openssl"
-version = "0.10.45"
+version = "0.10.59"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b102428fd03bc5edf97f62620f7298614c45cedf287c271e7ed450bbaf83f2e1"
+checksum = "7a257ad03cd8fb16ad4172fedf8094451e1af1c4b70097636ef2eac9a5f0cc33"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags 2.4.1",
  "cfg-if",
  "foreign-types",
  "libc",
@@ -2084,13 +2060,13 @@ dependencies = [
 
 [[package]]
 name = "openssl-macros"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b501e44f11665960c7e7fcf062c7d96a14ade4aa98116c004b2e37b5be7d736c"
+checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.107",
+ "syn 2.0.39",
 ]
 
 [[package]]
@@ -2101,22 +2077,15 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.80"
+version = "0.9.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23bbbf7854cd45b83958ebe919f0e8e516793727652e27fda10a8384cfc790b7"
+checksum = "40a4130519a360279579c2053038317e40eff64d13fd3f004f9e1b72b8a6aaf9"
 dependencies = [
- "autocfg",
  "cc",
  "libc",
  "pkg-config",
  "vcpkg",
 ]
-
-[[package]]
-name = "os_str_bytes"
-version = "6.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b7820b9daea5457c9f21c69448905d723fbd21136ccf521748f23fd49e723ee"
 
 [[package]]
 name = "p256"
@@ -2154,15 +2123,15 @@ dependencies = [
 
 [[package]]
 name = "parking_lot_core"
-version = "0.9.7"
+version = "0.9.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9069cbb9f99e3a5083476ccb29ceb1de18b9118cafa53e90c9551235de2b9521"
+checksum = "4c42a9226546d68acdd9c0a280d17ce19bfe27a46bf68784e4066115788d008e"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall 0.2.16",
+ "redox_syscall 0.4.1",
  "smallvec",
- "windows-sys 0.45.0",
+ "windows-targets",
 ]
 
 [[package]]
@@ -2185,15 +2154,15 @@ dependencies = [
 
 [[package]]
 name = "percent-encoding"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "478c572c3d73181ff3c2539045f6eb99e5491218eae919370993b890cdbdd98e"
+checksum = "9b2a4787296e9989611394c33f193f676704af1686e70b8f8033ab5ba9a35a94"
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.9"
+version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0a7ae3ac2f1173085d398531c705756c94a4c56843785df85a60c1a0afac116"
+checksum = "8afb450f006bf6385ca15ef45d71d2288452bc3683ce2e2cacc0d18e4be60b58"
 
 [[package]]
 name = "pin-utils"
@@ -2235,9 +2204,15 @@ dependencies = [
 
 [[package]]
 name = "pkg-config"
-version = "0.3.26"
+version = "0.3.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ac9a59f73473f1b8d852421e59e64809f025994837ef743615c6d0c5b305160"
+checksum = "26072860ba924cbfa98ea39c8c19b4dd6a4a25423dbdf219c1eca91aa0cf6964"
+
+[[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "ppv-lite86"
@@ -2247,42 +2222,18 @@ checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
 
 [[package]]
 name = "primeorder"
-version = "0.13.2"
+version = "0.13.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c2fcef82c0ec6eefcc179b978446c399b3cdf73c392c35604e399eee6df1ee3"
+checksum = "353e1ca18966c16d9deb1c69278edbc5f194139612772bd9537af60ac231e1e6"
 dependencies = [
  "elliptic-curve",
 ]
 
 [[package]]
-name = "proc-macro-error"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
-dependencies = [
- "proc-macro-error-attr",
- "proc-macro2",
- "quote",
- "syn 1.0.107",
- "version_check",
-]
-
-[[package]]
-name = "proc-macro-error-attr"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
-dependencies = [
- "proc-macro2",
- "quote",
- "version_check",
-]
-
-[[package]]
 name = "proc-macro2"
-version = "1.0.66"
+version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18fb31db3f9bddb2ea821cde30a9f70117e3f119938b5ee630b7403aa6e2ead9"
+checksum = "134c189feb4956b20f6f547d2cf727d4c0fe06722b20a0eec87ed445a97f92da"
 dependencies = [
  "unicode-ident",
 ]
@@ -2338,9 +2289,9 @@ dependencies = [
 
 [[package]]
 name = "rayon"
-version = "1.6.1"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db3a213adf02b3bcfd2d3846bb41cb22857d131789e01df434fb7e7bc0759b7"
+checksum = "9c27db03db7734835b3f53954b534c91069375ce6ccaa2e065441e07d9b6cdb1"
 dependencies = [
  "either",
  "rayon-core",
@@ -2348,23 +2299,12 @@ dependencies = [
 
 [[package]]
 name = "rayon-core"
-version = "1.10.2"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "356a0625f1954f730c0201cdab48611198dc6ce21f4acff55089b5a78e6e835b"
+checksum = "5ce3fb6ad83f861aac485e76e1985cd109d9a3713802152be56c3b1f0e0658ed"
 dependencies = [
- "crossbeam-channel",
  "crossbeam-deque",
  "crossbeam-utils",
- "num_cpus",
-]
-
-[[package]]
-name = "redox_syscall"
-version = "0.2.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
-dependencies = [
- "bitflags 1.3.2",
 ]
 
 [[package]]
@@ -2377,10 +2317,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "regex"
-version = "1.9.3"
+name = "redox_syscall"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81bc1d4caf89fac26a70747fe603c130093b53c773888797a6329091246d651a"
+checksum = "4722d768eff46b75989dd134e5c353f0d6296e5aaa3132e776cbdb56be7731aa"
+dependencies = [
+ "bitflags 1.3.2",
+]
+
+[[package]]
+name = "regex"
+version = "1.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "380b951a9c5e80ddfd6136919eef32310721aa4aacd4889a8d39124b026ab343"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -2390,9 +2339,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.3.6"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fed1ceff11a1dddaee50c9dc8e4938bd106e9d89ae372f192311e7da498e3b69"
+checksum = "5f804c7828047e88b2d32e2d7fe5a105da8ee3264f01902f796c8e067dc2483f"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -2401,15 +2350,15 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.7.5"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbb5fb1acd8a1a18b3dd5be62d25485eb770e05afb408a9627d14d451bae12da"
+checksum = "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f"
 
 [[package]]
 name = "reqwest"
-version = "0.11.20"
+version = "0.11.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e9ad3fe7488d7e34558a2033d45a0c90b72d97b4f80705666fea71472e2e6a1"
+checksum = "046cd98826c46c2ac8ddecae268eb5c2e58628688a5fc7a2643704a73faba95b"
 dependencies = [
  "async-compression",
  "base64",
@@ -2433,6 +2382,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_urlencoded",
+ "system-configuration",
  "tokio",
  "tokio-native-tls",
  "tokio-util",
@@ -2476,51 +2426,29 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustix"
-version = "0.36.8"
+name = "rustc-demangle"
+version = "0.1.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f43abb88211988493c1abb44a70efa56ff0ce98f233b7b276146f1f3f7ba9644"
-dependencies = [
- "bitflags 1.3.2",
- "errno 0.2.8",
- "io-lifetimes",
- "libc",
- "linux-raw-sys 0.1.4",
- "windows-sys 0.45.0",
-]
+checksum = "d626bb9dae77e28219937af045c257c28bfd3f69333c512553507f5f9798cb76"
 
 [[package]]
 name = "rustix"
-version = "0.37.19"
+version = "0.38.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "acf8729d8542766f1b2cf77eb034d52f40d375bb8b615d0b147089946e16613d"
+checksum = "9ad981d6c340a49cdc40a1028d9c6084ec7e9fa33fcb839cab656a267071e234"
 dependencies = [
- "bitflags 1.3.2",
- "errno 0.3.1",
- "io-lifetimes",
+ "bitflags 2.4.1",
+ "errno",
  "libc",
- "linux-raw-sys 0.3.7",
- "windows-sys 0.48.0",
-]
-
-[[package]]
-name = "rustix"
-version = "0.38.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19ed4fa021d81c8392ce04db050a3da9a60299050b7ae1cf482d862b54a7218f"
-dependencies = [
- "bitflags 2.4.0",
- "errno 0.3.1",
- "libc",
- "linux-raw-sys 0.4.5",
- "windows-sys 0.48.0",
+ "linux-raw-sys",
+ "windows-sys",
 ]
 
 [[package]]
 name = "ryu"
-version = "1.0.12"
+version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b4b9743ed687d4b4bcedf9ff5eaa7398495ae14e61cba0a295704edbc7decde"
+checksum = "1ad4cc8da4ef723ed60bced201181d83791ad433213d8c24efffda1eec85d741"
 
 [[package]]
 name = "same-file"
@@ -2533,18 +2461,18 @@ dependencies = [
 
 [[package]]
 name = "schannel"
-version = "0.1.21"
+version = "0.1.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "713cfb06c7059f3588fb8044c0fad1d09e3c01d225e25b9220dbfdcf16dbb1b3"
+checksum = "0c3733bf4cf7ea0880754e19cb5a462007c4a8c1914bff372ccc95b464f1df88"
 dependencies = [
- "windows-sys 0.42.0",
+ "windows-sys",
 ]
 
 [[package]]
 name = "scopeguard"
-version = "1.1.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "sec1"
@@ -2562,9 +2490,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework"
-version = "2.8.2"
+version = "2.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a332be01508d814fed64bf28f798a146d73792121129962fdf335bb3c49a4254"
+checksum = "05b64fb303737d99b81884b2c63433e9ae28abebe5eb5045dcdd175dc2ecf4de"
 dependencies = [
  "bitflags 1.3.2",
  "core-foundation",
@@ -2575,9 +2503,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework-sys"
-version = "2.8.0"
+version = "2.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31c9bb296072e961fcbd8853511dd39c2d8be2deb1e17c6860b1d30732b323b4"
+checksum = "e932934257d3b408ed8f30db49d85ea163bfe74961f017f405b025af298f0c7a"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -2585,29 +2513,29 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.188"
+version = "1.0.192"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf9e0fcba69a370eed61bcf2b728575f726b50b55cba78064753d708ddc7549e"
+checksum = "bca2a08484b285dcb282d0f67b26cadc0df8b19f8c12502c13d966bf9482f001"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.188"
+version = "1.0.192"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4eca7ac642d82aa35b60049a6eccb4be6be75e599bd2e9adb5f875a737654af2"
+checksum = "d6c7207fbec9faa48073f3e3074cbe553af6ea512d7c21ba46e434e70ea9fbc1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.29",
+ "syn 2.0.39",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.107"
+version = "1.0.108"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b420ce6e3d8bd882e9b243c6eed35dbc9a6110c9769e74b584e0d68d1f20c65"
+checksum = "3d1c7e3eac408d115102c4c24ad393e0821bb3a5df4d506a80f85f7a742a526b"
 dependencies = [
  "itoa",
  "ryu",
@@ -2628,9 +2556,9 @@ dependencies = [
 
 [[package]]
 name = "serde_yaml"
-version = "0.9.17"
+version = "0.9.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fb06d4b6cdaef0e0c51fa881acb721bed3c924cfaa71d9c94a3b771dfdf6567"
+checksum = "3cc7a1570e38322cfe4154732e5110f887ea57e22b76f4bfd32b5bdd3368666c"
 dependencies = [
  "indexmap",
  "itoa",
@@ -2657,10 +2585,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "signal-hook"
-version = "0.3.14"
+name = "shell-words"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a253b5e89e2698464fc26b545c9edceb338e18a89effeeecfea192c3025be29d"
+checksum = "24188a676b6ae68c3b2cb3a01be17fbf7240ce009799bb56d5b1409051e78fde"
+
+[[package]]
+name = "signal-hook"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8621587d4798caf8eb44879d42e56b9a93ea5dcd315a6487c357130095b62801"
 dependencies = [
  "libc",
  "signal-hook-registry",
@@ -2668,9 +2602,9 @@ dependencies = [
 
 [[package]]
 name = "signal-hook-registry"
-version = "1.4.0"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e51e73328dc4ac0c7ccbda3a494dfa03df1de2f46018127f60c693f2648455b0"
+checksum = "d8229b473baa5980ac72ef434c4415e70c4b5e71b423043adb4ba059f89c99a1"
 dependencies = [
  "libc",
 ]
@@ -2687,9 +2621,9 @@ dependencies = [
 
 [[package]]
 name = "signature"
-version = "2.1.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e1788eed21689f9cf370582dfc467ef36ed9c707f073528ddafa8d83e3b8500"
+checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
  "digest",
  "rand_core",
@@ -2697,30 +2631,40 @@ dependencies = [
 
 [[package]]
 name = "slab"
-version = "0.4.7"
+version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4614a76b2a8be0058caa9dbbaf66d988527d86d003c11a94fbd335d7661edcef"
+checksum = "8f92a496fb766b417c996b9c5e57daf2f7ad3b0bebe1ccfca4856390e3d3bb67"
 dependencies = [
  "autocfg",
 ]
 
 [[package]]
 name = "smallvec"
-version = "1.10.0"
+version = "1.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a507befe795404456341dfab10cef66ead4c041f62b8b11bbb92bffe5d0953e0"
+checksum = "4dccd0940a2dcdf68d092b8cbab7dc0ad8fa938bf95787e1b916b0e3d0e8e970"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "socket2"
-version = "0.4.7"
+version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02e2d2db9033d13a1567121ddd7a095ee144db4e1ca1b1bda3419bc0da294ebd"
+checksum = "9f7916fc008ca5542385b89a3d3ce689953c143e9304a9bf8beec1de48994c0d"
 dependencies = [
  "libc",
  "winapi",
+]
+
+[[package]]
+name = "socket2"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b5fac59a5cb5dd637972e5fca70daf0523c9067fcdc4842f053dae04a18f8e9"
+dependencies = [
+ "libc",
+ "windows-sys",
 ]
 
 [[package]]
@@ -2769,9 +2713,9 @@ checksum = "81cdd64d312baedb58e21336b31bc043b77e01cc99033ce76ef539f78e965ebc"
 
 [[package]]
 name = "syn"
-version = "1.0.107"
+version = "1.0.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f4064b5b16e03ae50984a5a8ed5d4f8803e6bc1fd170a3cda91a1be4b18e3f5"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2780,9 +2724,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.29"
+version = "2.0.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c324c494eba9d92503e6f1ef2e6df781e78f6a7705a0202d9801b198807d518a"
+checksum = "23e78b90f2fcf45d3e842032ce32e3f2d1545ba6636271dcbf24fa306d87be7a"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2790,57 +2734,70 @@ dependencies = [
 ]
 
 [[package]]
-name = "tempfile"
-version = "3.5.0"
+name = "system-configuration"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9fbec84f381d5795b08656e4912bec604d162bff9291d6189a78f4c8ab87998"
+checksum = "ba3a3adc5c275d719af8cb4272ea1c4a6d668a777f37e115f6d11ddbc1c8e0e7"
 dependencies = [
- "cfg-if",
- "fastrand 1.9.0",
- "redox_syscall 0.3.5",
- "rustix 0.37.19",
- "windows-sys 0.45.0",
+ "bitflags 1.3.2",
+ "core-foundation",
+ "system-configuration-sys",
 ]
 
 [[package]]
-name = "termcolor"
-version = "1.2.0"
+name = "system-configuration-sys"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be55cf8942feac5c765c2c993422806843c9a9a45d4d5c407ad6dd2ea95eb9b6"
+checksum = "a75fb188eb626b924683e3b95e3a48e63551fcfb51949de2f06a9d91dbee93c9"
 dependencies = [
- "winapi-util",
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ef1adac450ad7f4b3c28589471ade84f25f731a7a0fe30d71dfa9f60fd808e5"
+dependencies = [
+ "cfg-if",
+ "fastrand",
+ "redox_syscall 0.4.1",
+ "rustix",
+ "windows-sys",
 ]
 
 [[package]]
 name = "thiserror"
-version = "1.0.48"
+version = "1.0.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d6d7a740b8a666a7e828dd00da9c0dc290dff53154ea77ac109281de90589b7"
+checksum = "f9a7210f5c9a7156bb50aa36aed4c95afb51df0df00713949448cf9e97d382d2"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.48"
+version = "1.0.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49922ecae66cc8a249b77e68d1d0623c1b2c514f0060c27cdc68bd62a1219d35"
+checksum = "266b2e40bc00e5a6c09c3584011e08b06f123c00362c92b975ba9843aaaa14b8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.29",
+ "syn 2.0.39",
 ]
 
 [[package]]
 name = "time"
-version = "0.3.29"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "426f806f4089c493dcac0d24c29c01e2c38baf8e30f1b716ee37e83d200b18fe"
+checksum = "c4a34ab300f2dee6e562c10a046fc05e358b29f9bf92277f30c3c8d82275f6f5"
 dependencies = [
  "deranged",
  "itoa",
  "libc",
  "num_threads",
+ "powerfmt",
  "serde",
  "time-core",
  "time-macros",
@@ -2878,26 +2835,25 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.25.0"
+version = "1.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8e00990ebabbe4c14c08aca901caed183ecd5c09562a12c824bb53d3c3fd3af"
+checksum = "d0c014766411e834f7af5b8f4cf46257aab4036ca95e9d2c144a10f59ad6f5b9"
 dependencies = [
- "autocfg",
+ "backtrace",
  "bytes",
  "libc",
- "memchr",
  "mio",
  "num_cpus",
  "pin-project-lite",
- "socket2",
- "windows-sys 0.42.0",
+ "socket2 0.5.5",
+ "windows-sys",
 ]
 
 [[package]]
 name = "tokio-native-tls"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7d995660bd2b7f8c1568414c1126076c13fbb725c40112dc0120b78eb9b717b"
+checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
 dependencies = [
  "native-tls",
  "tokio",
@@ -2905,9 +2861,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.4"
+version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bb2e075f03b3d66d8d8785356224ba688d2906a371015e225beeb65ca92c740"
+checksum = "5419f34732d9eb6ee4c3578b7989078579b7f039cbbb9ca2c4da015749371e15"
 dependencies = [
  "bytes",
  "futures-core",
@@ -2925,20 +2881,19 @@ checksum = "b6bc1c9ce2b5135ac7f93c72918fc37feb872bdc6a5533a8b85eb4b86bfdae52"
 
 [[package]]
 name = "tracing"
-version = "0.1.37"
+version = "0.1.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ce8c33a8d48bd45d624a6e523445fd21ec13d3653cd51f681abf67418f54eb8"
+checksum = "c3523ab5a71916ccf420eebdf5521fcef02141234bbc0b8a49f2fdc4544364ef"
 dependencies = [
- "cfg-if",
  "pin-project-lite",
  "tracing-core",
 ]
 
 [[package]]
 name = "tracing-core"
-version = "0.1.30"
+version = "0.1.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24eb03ba0eab1fd845050058ce5e616558e8f8d8fca633e6b163fe25c797213a"
+checksum = "c06d3da6113f116aaee68e4d601191614c9053067f9ab7f6edbcb161237daa54"
 dependencies = [
  "once_cell",
 ]
@@ -2966,21 +2921,21 @@ dependencies = [
 
 [[package]]
 name = "unicode-bidi"
-version = "0.3.10"
+version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d54675592c1dbefd78cbd98db9bacd89886e1ca50692a0692baefffdeb92dd58"
+checksum = "92888ba5573ff080736b3648696b70cafad7d250551175acbaa4e0385b3e1460"
 
 [[package]]
 name = "unicode-bom"
-version = "2.0.2"
+version = "2.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98e90c70c9f0d4d1ee6d0a7d04aa06cb9bbd53d8cfbdd62a0269a7c2eb640552"
+checksum = "7eec5d1121208364f6793f7d2e222bf75a915c19557537745b195b253dd64217"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.6"
+version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84a22b9f218b40614adcb3f4ff08b703773ad44fa9423e4e0d346d5db86e4ebc"
+checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
 
 [[package]]
 name = "unicode-normalization"
@@ -2993,20 +2948,26 @@ dependencies = [
 
 [[package]]
 name = "unsafe-libyaml"
-version = "0.2.5"
+version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc7ed8ba44ca06be78ea1ad2c3682a43349126c8818054231ee6f4748012aed2"
+checksum = "f28467d3e1d3c6586d8f25fa243f544f5800fec42d97032474e17222c2b75cfa"
 
 [[package]]
 name = "url"
-version = "2.3.1"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d68c799ae75762b8c3fe375feb6600ef5602c883c5d21eb51c09f22b83c4643"
+checksum = "143b538f18257fac9cad154828a57c6bf5157e1aa604d4816b5995bf6de87ae5"
 dependencies = [
  "form_urlencoded",
  "idna",
  "percent-encoding",
 ]
+
+[[package]]
+name = "utf8parse"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
 
 [[package]]
 name = "vcpkg"
@@ -3022,22 +2983,20 @@ checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
 name = "walkdir"
-version = "2.3.2"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "808cf2735cd4b6866113f648b791c6adc5714537bc222d9347bb203386ffda56"
+checksum = "d71d857dc86794ca4c280d616f7da00d2dbfd8cd788846559a6813e6aa4b54ee"
 dependencies = [
  "same-file",
- "winapi",
  "winapi-util",
 ]
 
 [[package]]
 name = "want"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ce8a968cb1cd110d136ff8b819a556d6fb6d919363c61534f6860c7eb172ba0"
+checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
 dependencies = [
- "log",
  "try-lock",
 ]
 
@@ -3049,9 +3008,9 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.84"
+version = "0.2.88"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31f8dcbc21f30d9b8f2ea926ecb58f6b91192c17e9d33594b3df58b2007ca53b"
+checksum = "7daec296f25a1bae309c0cd5c29c4b260e510e6d813c286b19eaadf409d40fce"
 dependencies = [
  "cfg-if",
  "wasm-bindgen-macro",
@@ -3059,24 +3018,24 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.84"
+version = "0.2.88"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95ce90fd5bcc06af55a641a86428ee4229e44e07033963a2290a8e241607ccb9"
+checksum = "e397f4664c0e4e428e8313a469aaa58310d302159845980fd23b0f22a847f217"
 dependencies = [
  "bumpalo",
  "log",
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 1.0.107",
+ "syn 2.0.39",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.34"
+version = "0.4.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f219e0d211ba40266969f6dbdd90636da12f75bee4fc9d6c23d1260dadb51454"
+checksum = "9afec9963e3d0994cac82455b2b3502b81a7f40f9a0d32181f7528d9f4b43e02"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -3086,9 +3045,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.84"
+version = "0.2.88"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c21f77c0bedc37fd5dc21f897894a5ca01e7bb159884559461862ae90c0b4c5"
+checksum = "5961017b3b08ad5f3fe39f1e79877f8ee7c23c5e5fd5eb80de95abc41f1f16b2"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -3096,28 +3055,28 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.84"
+version = "0.2.88"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2aff81306fcac3c7515ad4e177f521b5c9a15f2b08f4e32d823066102f35a5f6"
+checksum = "c5353b8dab669f5e10f5bd76df26a9360c748f054f862ff5f3f8aae0c7fb3907"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.107",
+ "syn 2.0.39",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.84"
+version = "0.2.88"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0046fef7e28c3804e5e38bfa31ea2a0f73905319b677e57ebe37e49358989b5d"
+checksum = "0d046c5d029ba91a1ed14da14dca44b68bf2f124cfbaf741c54151fdb3e0750b"
 
 [[package]]
 name = "web-sys"
-version = "0.3.61"
+version = "0.3.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e33b99f4b23ba3eec1a53ac264e35a755f00e966e0065077d6027c0f575b0b97"
+checksum = "5db499c5f66323272151db0e666cd34f78617522fb0c1604d31a27c50c206a85"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -3141,9 +3100,9 @@ checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 
 [[package]]
 name = "winapi-util"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178"
+checksum = "f29e6f9198ba0d26b4c9f07dbe6f9ed633e1f3d5b8b414090084349e46a52596"
 dependencies = [
  "winapi",
 ]
@@ -3160,31 +3119,7 @@ version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e686886bc078bc1b0b600cac0147aadb815089b6e4da64016cbd754b6342700f"
 dependencies = [
- "windows-targets 0.48.0",
-]
-
-[[package]]
-name = "windows-sys"
-version = "0.42.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a3e1820f08b8513f676f7ab6c1f99ff312fb97b553d30ff4dd86f9f15728aa7"
-dependencies = [
- "windows_aarch64_gnullvm 0.42.1",
- "windows_aarch64_msvc 0.42.1",
- "windows_i686_gnu 0.42.1",
- "windows_i686_msvc 0.42.1",
- "windows_x86_64_gnu 0.42.1",
- "windows_x86_64_gnullvm 0.42.1",
- "windows_x86_64_msvc 0.42.1",
-]
-
-[[package]]
-name = "windows-sys"
-version = "0.45.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
-dependencies = [
- "windows-targets 0.42.1",
+ "windows-targets",
 ]
 
 [[package]]
@@ -3193,128 +3128,71 @@ version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
 dependencies = [
- "windows-targets 0.48.0",
+ "windows-targets",
 ]
 
 [[package]]
 name = "windows-targets"
-version = "0.42.1"
+version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e2522491fbfcd58cc84d47aeb2958948c4b8982e9a2d8a2a35bbaed431390e7"
+checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
 dependencies = [
- "windows_aarch64_gnullvm 0.42.1",
- "windows_aarch64_msvc 0.42.1",
- "windows_i686_gnu 0.42.1",
- "windows_i686_msvc 0.42.1",
- "windows_x86_64_gnu 0.42.1",
- "windows_x86_64_gnullvm 0.42.1",
- "windows_x86_64_msvc 0.42.1",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.48.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b1eb6f0cd7c80c79759c929114ef071b87354ce476d9d94271031c0497adfd5"
-dependencies = [
- "windows_aarch64_gnullvm 0.48.0",
- "windows_aarch64_msvc 0.48.0",
- "windows_i686_gnu 0.48.0",
- "windows_i686_msvc 0.48.0",
- "windows_x86_64_gnu 0.48.0",
- "windows_x86_64_gnullvm 0.48.0",
- "windows_x86_64_msvc 0.48.0",
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
 ]
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.42.1"
+version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c9864e83243fdec7fc9c5444389dcbbfd258f745e7853198f365e3c4968a608"
-
-[[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.48.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91ae572e1b79dba883e0d315474df7305d12f569b400fcf90581b06062f7e1bc"
+checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.42.1"
+version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c8b1b673ffc16c47a9ff48570a9d85e25d265735c503681332589af6253c6c7"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.48.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2ef27e0d7bdfcfc7b868b317c1d32c641a6fe4629c171b8928c7b08d98d7cf3"
+checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.42.1"
+version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de3887528ad530ba7bdbb1faa8275ec7a1155a45ffa57c37993960277145d640"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.48.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "622a1962a7db830d6fd0a69683c80a18fda201879f0f447f065a3b7467daa241"
+checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.42.1"
+version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf4d1122317eddd6ff351aa852118a2418ad4214e6613a50e0191f7004372605"
-
-[[package]]
-name = "windows_i686_msvc"
-version = "0.48.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4542c6e364ce21bf45d69fdd2a8e455fa38d316158cfd43b3ac1c5b1b19f8e00"
+checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.42.1"
+version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1040f221285e17ebccbc2591ffdc2d44ee1f9186324dd3e84e99ac68d699c45"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.48.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca2b8a661f7628cbd23440e50b05d705db3686f894fc9580820623656af974b1"
+checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.42.1"
+version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "628bfdf232daa22b0d64fdb62b09fcc36bb01f05a3939e20ab73aaf9470d0463"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.48.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7896dbc1f41e08872e9d5e8f8baa8fdd2677f29468c4e156210174edc7f7b953"
+checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.42.1"
+version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "447660ad36a13288b1db4d4248e857b510e8c3a225c822ba4fb748c0aafecffd"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.48.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a515f5799fe4961cb532f983ce2b23082366b898e52ffbce459c86f67c8378a"
+checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "winnow"
-version = "0.5.14"
+version = "0.5.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d09770118a7eb1ccaf4a594a221334119a44a814fcb0d31c5b85e83e97227a97"
+checksum = "829846f3e3db426d4cee4510841b71a8e58aa2a76b1132579487ae430ccd9c7b"
 dependencies = [
  "memchr",
 ]
@@ -3326,7 +3204,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "524e57b2c537c0f9b1e69f1965311ec12182b4122e45035b1508cd24d2adadb1"
 dependencies = [
  "cfg-if",
- "windows-sys 0.48.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -3345,7 +3223,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e2c411759b501fb9501aac2b1b2d287a6e93e5bdcf13c25306b23e1b716dd0e"
 
 [[package]]
-name = "zeroize"
-version = "1.6.0"
+name = "zerocopy"
+version = "0.7.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a0956f1ba7c7909bfb66c2e9e4124ab6f6482560f6628b5aaeba39207c9aad9"
+checksum = "e97e415490559a91254a2979b4829267a57d2fcd741a98eee8b722fb57289aa0"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.7.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd7e48ccf166952882ca8bd778a43502c64f33bf94c12ebe2a7f08e5a0f6689f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.39",
+]
+
+[[package]]
+name = "zeroize"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "525b4ec142c6b68a2d10f01f7bbf6755599ca3f81ea53b8431b7dd348f5fdb2d"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -446,6 +446,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3b7eb4404b8195a9abb6356f4ac07d8ba267045c8d6d220ac4dc992e6cc75df"
 
 [[package]]
+name = "dashmap"
+version = "5.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "978747c1d849a7d2ee5e8adc0159961c48fb7e5db2f06af6723b80123bb53856"
+dependencies = [
+ "cfg-if",
+ "hashbrown 0.14.2",
+ "lock_api",
+ "once_cell",
+ "parking_lot_core",
+]
+
+[[package]]
 name = "der"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -572,9 +585,9 @@ dependencies = [
 
 [[package]]
 name = "faster-hex"
-version = "0.8.1"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "239f7bfb930f820ab16a9cd95afc26f88264cf6905c960b340a615384aa3338a"
+checksum = "a2a2b11eda1d40935b26cf18f6833c526845ae8c41e58d09af6adeb6f0269183"
 dependencies = [
  "serde",
 ]
@@ -725,23 +738,24 @@ checksum = "6fb8d784f27acf97159b40fc4db5ecd8aa23b9ad5ef69cdd136d3bc80665f0c0"
 
 [[package]]
 name = "gix"
-version = "0.55.2"
-source = "git+https://github.com/Byron/gitoxide?rev=2b80d842#2b80d8424196088d4ccc36914c87e320e4416ea1"
+version = "0.56.0"
+source = "git+https://github.com/Byron/gitoxide?rev=281fda06#281fda06a89b1d38cf6afeda23cf80a68486140b"
 dependencies = [
  "gix-actor",
  "gix-archive",
  "gix-attributes",
+ "gix-command",
  "gix-commitgraph",
  "gix-config",
  "gix-credentials",
  "gix-date",
  "gix-diff",
  "gix-discover",
- "gix-features",
+ "gix-features 0.36.1 (git+https://github.com/Byron/gitoxide?rev=281fda06)",
  "gix-filter",
- "gix-fs",
+ "gix-fs 0.8.1 (git+https://github.com/Byron/gitoxide?rev=281fda06)",
  "gix-glob",
- "gix-hash",
+ "gix-hash 0.13.2",
  "gix-hashtable",
  "gix-ignore",
  "gix-index",
@@ -763,8 +777,8 @@ dependencies = [
  "gix-sec",
  "gix-status",
  "gix-submodule",
- "gix-tempfile",
- "gix-trace",
+ "gix-tempfile 11.0.1 (git+https://github.com/Byron/gitoxide?rev=281fda06)",
+ "gix-trace 0.1.4 (git+https://github.com/Byron/gitoxide?rev=281fda06)",
  "gix-transport",
  "gix-traverse",
  "gix-url",
@@ -786,8 +800,8 @@ dependencies = [
 
 [[package]]
 name = "gix-actor"
-version = "0.28.0"
-source = "git+https://github.com/Byron/gitoxide?rev=2b80d842#2b80d8424196088d4ccc36914c87e320e4416ea1"
+version = "0.28.1"
+source = "git+https://github.com/Byron/gitoxide?rev=281fda06#281fda06a89b1d38cf6afeda23cf80a68486140b"
 dependencies = [
  "bstr",
  "btoi",
@@ -800,8 +814,8 @@ dependencies = [
 
 [[package]]
 name = "gix-archive"
-version = "0.6.0"
-source = "git+https://github.com/Byron/gitoxide?rev=2b80d842#2b80d8424196088d4ccc36914c87e320e4416ea1"
+version = "0.7.0"
+source = "git+https://github.com/Byron/gitoxide?rev=281fda06#281fda06a89b1d38cf6afeda23cf80a68486140b"
 dependencies = [
  "bstr",
  "gix-date",
@@ -812,14 +826,14 @@ dependencies = [
 
 [[package]]
 name = "gix-attributes"
-version = "0.20.0"
-source = "git+https://github.com/Byron/gitoxide?rev=2b80d842#2b80d8424196088d4ccc36914c87e320e4416ea1"
+version = "0.20.1"
+source = "git+https://github.com/Byron/gitoxide?rev=281fda06#281fda06a89b1d38cf6afeda23cf80a68486140b"
 dependencies = [
  "bstr",
  "gix-glob",
  "gix-path",
  "gix-quote",
- "gix-trace",
+ "gix-trace 0.1.4 (git+https://github.com/Byron/gitoxide?rev=281fda06)",
  "kstring",
  "serde",
  "smallvec",
@@ -829,40 +843,40 @@ dependencies = [
 
 [[package]]
 name = "gix-bitmap"
-version = "0.2.7"
-source = "git+https://github.com/Byron/gitoxide?rev=2b80d842#2b80d8424196088d4ccc36914c87e320e4416ea1"
+version = "0.2.8"
+source = "git+https://github.com/Byron/gitoxide?rev=281fda06#281fda06a89b1d38cf6afeda23cf80a68486140b"
 dependencies = [
  "thiserror",
 ]
 
 [[package]]
 name = "gix-chunk"
-version = "0.4.4"
-source = "git+https://github.com/Byron/gitoxide?rev=2b80d842#2b80d8424196088d4ccc36914c87e320e4416ea1"
+version = "0.4.5"
+source = "git+https://github.com/Byron/gitoxide?rev=281fda06#281fda06a89b1d38cf6afeda23cf80a68486140b"
 dependencies = [
  "thiserror",
 ]
 
 [[package]]
 name = "gix-command"
-version = "0.2.10"
-source = "git+https://github.com/Byron/gitoxide?rev=2b80d842#2b80d8424196088d4ccc36914c87e320e4416ea1"
+version = "0.3.0"
+source = "git+https://github.com/Byron/gitoxide?rev=281fda06#281fda06a89b1d38cf6afeda23cf80a68486140b"
 dependencies = [
  "bstr",
  "gix-path",
- "gix-trace",
+ "gix-trace 0.1.4 (git+https://github.com/Byron/gitoxide?rev=281fda06)",
  "shell-words",
 ]
 
 [[package]]
 name = "gix-commitgraph"
-version = "0.22.0"
-source = "git+https://github.com/Byron/gitoxide?rev=2b80d842#2b80d8424196088d4ccc36914c87e320e4416ea1"
+version = "0.22.1"
+source = "git+https://github.com/Byron/gitoxide?rev=281fda06#281fda06a89b1d38cf6afeda23cf80a68486140b"
 dependencies = [
  "bstr",
  "gix-chunk",
- "gix-features",
- "gix-hash",
+ "gix-features 0.36.1 (git+https://github.com/Byron/gitoxide?rev=281fda06)",
+ "gix-hash 0.13.2",
  "memmap2",
  "serde",
  "thiserror",
@@ -870,12 +884,12 @@ dependencies = [
 
 [[package]]
 name = "gix-config"
-version = "0.31.0"
-source = "git+https://github.com/Byron/gitoxide?rev=2b80d842#2b80d8424196088d4ccc36914c87e320e4416ea1"
+version = "0.32.1"
+source = "git+https://github.com/Byron/gitoxide?rev=281fda06#281fda06a89b1d38cf6afeda23cf80a68486140b"
 dependencies = [
  "bstr",
  "gix-config-value",
- "gix-features",
+ "gix-features 0.36.1 (git+https://github.com/Byron/gitoxide?rev=281fda06)",
  "gix-glob",
  "gix-path",
  "gix-ref",
@@ -890,8 +904,8 @@ dependencies = [
 
 [[package]]
 name = "gix-config-value"
-version = "0.14.0"
-source = "git+https://github.com/Byron/gitoxide?rev=2b80d842#2b80d8424196088d4ccc36914c87e320e4416ea1"
+version = "0.14.1"
+source = "git+https://github.com/Byron/gitoxide?rev=281fda06#281fda06a89b1d38cf6afeda23cf80a68486140b"
 dependencies = [
  "bitflags 2.4.1",
  "bstr",
@@ -902,8 +916,8 @@ dependencies = [
 
 [[package]]
 name = "gix-credentials"
-version = "0.21.0"
-source = "git+https://github.com/Byron/gitoxide?rev=2b80d842#2b80d8424196088d4ccc36914c87e320e4416ea1"
+version = "0.22.0"
+source = "git+https://github.com/Byron/gitoxide?rev=281fda06#281fda06a89b1d38cf6afeda23cf80a68486140b"
 dependencies = [
  "bstr",
  "gix-command",
@@ -911,7 +925,7 @@ dependencies = [
  "gix-path",
  "gix-prompt",
  "gix-sec",
- "gix-trace",
+ "gix-trace 0.1.4 (git+https://github.com/Byron/gitoxide?rev=281fda06)",
  "gix-url",
  "serde",
  "thiserror",
@@ -919,8 +933,8 @@ dependencies = [
 
 [[package]]
 name = "gix-date"
-version = "0.8.0"
-source = "git+https://github.com/Byron/gitoxide?rev=2b80d842#2b80d8424196088d4ccc36914c87e320e4416ea1"
+version = "0.8.1"
+source = "git+https://github.com/Byron/gitoxide?rev=281fda06#281fda06a89b1d38cf6afeda23cf80a68486140b"
 dependencies = [
  "bstr",
  "itoa",
@@ -931,24 +945,31 @@ dependencies = [
 
 [[package]]
 name = "gix-diff"
-version = "0.37.0"
-source = "git+https://github.com/Byron/gitoxide?rev=2b80d842#2b80d8424196088d4ccc36914c87e320e4416ea1"
+version = "0.38.0"
+source = "git+https://github.com/Byron/gitoxide?rev=281fda06#281fda06a89b1d38cf6afeda23cf80a68486140b"
 dependencies = [
  "bstr",
- "gix-hash",
+ "gix-command",
+ "gix-filter",
+ "gix-fs 0.8.1 (git+https://github.com/Byron/gitoxide?rev=281fda06)",
+ "gix-hash 0.13.2",
  "gix-object",
+ "gix-path",
+ "gix-tempfile 11.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "gix-trace 0.1.4 (git+https://github.com/Byron/gitoxide?rev=281fda06)",
+ "gix-worktree",
  "imara-diff",
  "thiserror",
 ]
 
 [[package]]
 name = "gix-discover"
-version = "0.26.0"
-source = "git+https://github.com/Byron/gitoxide?rev=2b80d842#2b80d8424196088d4ccc36914c87e320e4416ea1"
+version = "0.27.0"
+source = "git+https://github.com/Byron/gitoxide?rev=281fda06#281fda06a89b1d38cf6afeda23cf80a68486140b"
 dependencies = [
  "bstr",
  "dunce",
- "gix-hash",
+ "gix-hash 0.13.2",
  "gix-path",
  "gix-ref",
  "gix-sec",
@@ -957,16 +978,27 @@ dependencies = [
 
 [[package]]
 name = "gix-features"
-version = "0.36.0"
-source = "git+https://github.com/Byron/gitoxide?rev=2b80d842#2b80d8424196088d4ccc36914c87e320e4416ea1"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d46a4a5c6bb5bebec9c0d18b65ada20e6517dbd7cf855b87dd4bbdce3a771b2"
+dependencies = [
+ "gix-hash 0.13.3",
+ "gix-trace 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc",
+]
+
+[[package]]
+name = "gix-features"
+version = "0.36.1"
+source = "git+https://github.com/Byron/gitoxide?rev=281fda06#281fda06a89b1d38cf6afeda23cf80a68486140b"
 dependencies = [
  "bytes",
  "bytesize",
  "crc32fast",
  "crossbeam-channel",
  "flate2",
- "gix-hash",
- "gix-trace",
+ "gix-hash 0.13.2",
+ "gix-trace 0.1.4 (git+https://github.com/Byron/gitoxide?rev=281fda06)",
  "jwalk",
  "libc",
  "once_cell",
@@ -979,47 +1011,57 @@ dependencies = [
 
 [[package]]
 name = "gix-filter"
-version = "0.6.0"
-source = "git+https://github.com/Byron/gitoxide?rev=2b80d842#2b80d8424196088d4ccc36914c87e320e4416ea1"
+version = "0.7.0"
+source = "git+https://github.com/Byron/gitoxide?rev=281fda06#281fda06a89b1d38cf6afeda23cf80a68486140b"
 dependencies = [
  "bstr",
  "encoding_rs",
  "gix-attributes",
  "gix-command",
- "gix-hash",
+ "gix-hash 0.13.2",
  "gix-object",
  "gix-packetline-blocking",
  "gix-path",
  "gix-quote",
- "gix-trace",
+ "gix-trace 0.1.4 (git+https://github.com/Byron/gitoxide?rev=281fda06)",
+ "gix-utils",
  "smallvec",
  "thiserror",
 ]
 
 [[package]]
 name = "gix-fs"
-version = "0.8.0"
-source = "git+https://github.com/Byron/gitoxide?rev=2b80d842#2b80d8424196088d4ccc36914c87e320e4416ea1"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20e86eb040f5776a5ade092282e51cdcad398adb77d948b88d17583c2ae4e107"
 dependencies = [
- "gix-features",
+ "gix-features 0.36.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "gix-fs"
+version = "0.8.1"
+source = "git+https://github.com/Byron/gitoxide?rev=281fda06#281fda06a89b1d38cf6afeda23cf80a68486140b"
+dependencies = [
+ "gix-features 0.36.1 (git+https://github.com/Byron/gitoxide?rev=281fda06)",
 ]
 
 [[package]]
 name = "gix-glob"
-version = "0.14.0"
-source = "git+https://github.com/Byron/gitoxide?rev=2b80d842#2b80d8424196088d4ccc36914c87e320e4416ea1"
+version = "0.14.1"
+source = "git+https://github.com/Byron/gitoxide?rev=281fda06#281fda06a89b1d38cf6afeda23cf80a68486140b"
 dependencies = [
  "bitflags 2.4.1",
  "bstr",
- "gix-features",
+ "gix-features 0.36.1 (git+https://github.com/Byron/gitoxide?rev=281fda06)",
  "gix-path",
  "serde",
 ]
 
 [[package]]
 name = "gix-hash"
-version = "0.13.1"
-source = "git+https://github.com/Byron/gitoxide?rev=2b80d842#2b80d8424196088d4ccc36914c87e320e4416ea1"
+version = "0.13.2"
+source = "git+https://github.com/Byron/gitoxide?rev=281fda06#281fda06a89b1d38cf6afeda23cf80a68486140b"
 dependencies = [
  "faster-hex",
  "serde",
@@ -1027,19 +1069,29 @@ dependencies = [
 ]
 
 [[package]]
-name = "gix-hashtable"
-version = "0.4.0"
-source = "git+https://github.com/Byron/gitoxide?rev=2b80d842#2b80d8424196088d4ccc36914c87e320e4416ea1"
+name = "gix-hash"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f8cf8c2266f63e582b7eb206799b63aa5fa68ee510ad349f637dfe2d0653de0"
 dependencies = [
- "gix-hash",
+ "faster-hex",
+ "thiserror",
+]
+
+[[package]]
+name = "gix-hashtable"
+version = "0.4.1"
+source = "git+https://github.com/Byron/gitoxide?rev=281fda06#281fda06a89b1d38cf6afeda23cf80a68486140b"
+dependencies = [
+ "gix-hash 0.13.2",
  "hashbrown 0.14.2",
  "parking_lot",
 ]
 
 [[package]]
 name = "gix-ignore"
-version = "0.9.0"
-source = "git+https://github.com/Byron/gitoxide?rev=2b80d842#2b80d8424196088d4ccc36914c87e320e4416ea1"
+version = "0.9.1"
+source = "git+https://github.com/Byron/gitoxide?rev=281fda06#281fda06a89b1d38cf6afeda23cf80a68486140b"
 dependencies = [
  "bstr",
  "gix-glob",
@@ -1050,17 +1102,17 @@ dependencies = [
 
 [[package]]
 name = "gix-index"
-version = "0.26.0"
-source = "git+https://github.com/Byron/gitoxide?rev=2b80d842#2b80d8424196088d4ccc36914c87e320e4416ea1"
+version = "0.27.0"
+source = "git+https://github.com/Byron/gitoxide?rev=281fda06#281fda06a89b1d38cf6afeda23cf80a68486140b"
 dependencies = [
  "bitflags 2.4.1",
  "bstr",
  "btoi",
  "filetime",
  "gix-bitmap",
- "gix-features",
- "gix-fs",
- "gix-hash",
+ "gix-features 0.36.1 (git+https://github.com/Byron/gitoxide?rev=281fda06)",
+ "gix-fs 0.8.1 (git+https://github.com/Byron/gitoxide?rev=281fda06)",
+ "gix-hash 0.13.2",
  "gix-lock",
  "gix-object",
  "gix-traverse",
@@ -1075,18 +1127,18 @@ dependencies = [
 
 [[package]]
 name = "gix-lock"
-version = "11.0.0"
-source = "git+https://github.com/Byron/gitoxide?rev=2b80d842#2b80d8424196088d4ccc36914c87e320e4416ea1"
+version = "11.0.1"
+source = "git+https://github.com/Byron/gitoxide?rev=281fda06#281fda06a89b1d38cf6afeda23cf80a68486140b"
 dependencies = [
- "gix-tempfile",
+ "gix-tempfile 11.0.1 (git+https://github.com/Byron/gitoxide?rev=281fda06)",
  "gix-utils",
  "thiserror",
 ]
 
 [[package]]
 name = "gix-macros"
-version = "0.1.0"
-source = "git+https://github.com/Byron/gitoxide?rev=2b80d842#2b80d8424196088d4ccc36914c87e320e4416ea1"
+version = "0.1.1"
+source = "git+https://github.com/Byron/gitoxide?rev=281fda06#281fda06a89b1d38cf6afeda23cf80a68486140b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1095,8 +1147,8 @@ dependencies = [
 
 [[package]]
 name = "gix-mailmap"
-version = "0.20.0"
-source = "git+https://github.com/Byron/gitoxide?rev=2b80d842#2b80d8424196088d4ccc36914c87e320e4416ea1"
+version = "0.20.1"
+source = "git+https://github.com/Byron/gitoxide?rev=281fda06#281fda06a89b1d38cf6afeda23cf80a68486140b"
 dependencies = [
  "bstr",
  "gix-actor",
@@ -1107,13 +1159,13 @@ dependencies = [
 
 [[package]]
 name = "gix-negotiate"
-version = "0.9.0"
-source = "git+https://github.com/Byron/gitoxide?rev=2b80d842#2b80d8424196088d4ccc36914c87e320e4416ea1"
+version = "0.10.0"
+source = "git+https://github.com/Byron/gitoxide?rev=281fda06#281fda06a89b1d38cf6afeda23cf80a68486140b"
 dependencies = [
  "bitflags 2.4.1",
  "gix-commitgraph",
  "gix-date",
- "gix-hash",
+ "gix-hash 0.13.2",
  "gix-object",
  "gix-revwalk",
  "smallvec",
@@ -1122,15 +1174,15 @@ dependencies = [
 
 [[package]]
 name = "gix-object"
-version = "0.38.0"
-source = "git+https://github.com/Byron/gitoxide?rev=2b80d842#2b80d8424196088d4ccc36914c87e320e4416ea1"
+version = "0.39.0"
+source = "git+https://github.com/Byron/gitoxide?rev=281fda06#281fda06a89b1d38cf6afeda23cf80a68486140b"
 dependencies = [
  "bstr",
  "btoi",
  "gix-actor",
  "gix-date",
- "gix-features",
- "gix-hash",
+ "gix-features 0.36.1 (git+https://github.com/Byron/gitoxide?rev=281fda06)",
+ "gix-hash 0.13.2",
  "gix-validate",
  "itoa",
  "serde",
@@ -1141,13 +1193,13 @@ dependencies = [
 
 [[package]]
 name = "gix-odb"
-version = "0.54.0"
-source = "git+https://github.com/Byron/gitoxide?rev=2b80d842#2b80d8424196088d4ccc36914c87e320e4416ea1"
+version = "0.55.0"
+source = "git+https://github.com/Byron/gitoxide?rev=281fda06#281fda06a89b1d38cf6afeda23cf80a68486140b"
 dependencies = [
  "arc-swap",
  "gix-date",
- "gix-features",
- "gix-hash",
+ "gix-features 0.36.1 (git+https://github.com/Byron/gitoxide?rev=281fda06)",
+ "gix-hash 0.13.2",
  "gix-object",
  "gix-pack",
  "gix-path",
@@ -1160,17 +1212,17 @@ dependencies = [
 
 [[package]]
 name = "gix-pack"
-version = "0.44.0"
-source = "git+https://github.com/Byron/gitoxide?rev=2b80d842#2b80d8424196088d4ccc36914c87e320e4416ea1"
+version = "0.45.0"
+source = "git+https://github.com/Byron/gitoxide?rev=281fda06#281fda06a89b1d38cf6afeda23cf80a68486140b"
 dependencies = [
  "clru",
  "gix-chunk",
- "gix-features",
- "gix-hash",
+ "gix-features 0.36.1 (git+https://github.com/Byron/gitoxide?rev=281fda06)",
+ "gix-hash 0.13.2",
  "gix-hashtable",
  "gix-object",
  "gix-path",
- "gix-tempfile",
+ "gix-tempfile 11.0.1 (git+https://github.com/Byron/gitoxide?rev=281fda06)",
  "memmap2",
  "parking_lot",
  "serde",
@@ -1181,33 +1233,33 @@ dependencies = [
 
 [[package]]
 name = "gix-packetline"
-version = "0.16.7"
-source = "git+https://github.com/Byron/gitoxide?rev=2b80d842#2b80d8424196088d4ccc36914c87e320e4416ea1"
+version = "0.17.0"
+source = "git+https://github.com/Byron/gitoxide?rev=281fda06#281fda06a89b1d38cf6afeda23cf80a68486140b"
 dependencies = [
  "bstr",
  "faster-hex",
- "gix-trace",
+ "gix-trace 0.1.4 (git+https://github.com/Byron/gitoxide?rev=281fda06)",
  "thiserror",
 ]
 
 [[package]]
 name = "gix-packetline-blocking"
-version = "0.16.6"
-source = "git+https://github.com/Byron/gitoxide?rev=2b80d842#2b80d8424196088d4ccc36914c87e320e4416ea1"
+version = "0.17.0"
+source = "git+https://github.com/Byron/gitoxide?rev=281fda06#281fda06a89b1d38cf6afeda23cf80a68486140b"
 dependencies = [
  "bstr",
  "faster-hex",
- "gix-trace",
+ "gix-trace 0.1.4 (git+https://github.com/Byron/gitoxide?rev=281fda06)",
  "thiserror",
 ]
 
 [[package]]
 name = "gix-path"
-version = "0.10.0"
-source = "git+https://github.com/Byron/gitoxide?rev=2b80d842#2b80d8424196088d4ccc36914c87e320e4416ea1"
+version = "0.10.1"
+source = "git+https://github.com/Byron/gitoxide?rev=281fda06#281fda06a89b1d38cf6afeda23cf80a68486140b"
 dependencies = [
  "bstr",
- "gix-trace",
+ "gix-trace 0.1.4 (git+https://github.com/Byron/gitoxide?rev=281fda06)",
  "home",
  "once_cell",
  "thiserror",
@@ -1215,8 +1267,8 @@ dependencies = [
 
 [[package]]
 name = "gix-pathspec"
-version = "0.4.0"
-source = "git+https://github.com/Byron/gitoxide?rev=2b80d842#2b80d8424196088d4ccc36914c87e320e4416ea1"
+version = "0.4.1"
+source = "git+https://github.com/Byron/gitoxide?rev=281fda06#281fda06a89b1d38cf6afeda23cf80a68486140b"
 dependencies = [
  "bitflags 2.4.1",
  "bstr",
@@ -1229,8 +1281,8 @@ dependencies = [
 
 [[package]]
 name = "gix-prompt"
-version = "0.7.0"
-source = "git+https://github.com/Byron/gitoxide?rev=2b80d842#2b80d8424196088d4ccc36914c87e320e4416ea1"
+version = "0.8.0"
+source = "git+https://github.com/Byron/gitoxide?rev=281fda06#281fda06a89b1d38cf6afeda23cf80a68486140b"
 dependencies = [
  "gix-command",
  "gix-config-value",
@@ -1241,15 +1293,15 @@ dependencies = [
 
 [[package]]
 name = "gix-protocol"
-version = "0.41.1"
-source = "git+https://github.com/Byron/gitoxide?rev=2b80d842#2b80d8424196088d4ccc36914c87e320e4416ea1"
+version = "0.42.0"
+source = "git+https://github.com/Byron/gitoxide?rev=281fda06#281fda06a89b1d38cf6afeda23cf80a68486140b"
 dependencies = [
  "bstr",
  "btoi",
  "gix-credentials",
  "gix-date",
- "gix-features",
- "gix-hash",
+ "gix-features 0.36.1 (git+https://github.com/Byron/gitoxide?rev=281fda06)",
+ "gix-hash 0.13.2",
  "gix-transport",
  "maybe-async",
  "serde",
@@ -1259,8 +1311,8 @@ dependencies = [
 
 [[package]]
 name = "gix-quote"
-version = "0.4.7"
-source = "git+https://github.com/Byron/gitoxide?rev=2b80d842#2b80d8424196088d4ccc36914c87e320e4416ea1"
+version = "0.4.8"
+source = "git+https://github.com/Byron/gitoxide?rev=281fda06#281fda06a89b1d38cf6afeda23cf80a68486140b"
 dependencies = [
  "bstr",
  "btoi",
@@ -1269,18 +1321,18 @@ dependencies = [
 
 [[package]]
 name = "gix-ref"
-version = "0.38.0"
-source = "git+https://github.com/Byron/gitoxide?rev=2b80d842#2b80d8424196088d4ccc36914c87e320e4416ea1"
+version = "0.39.0"
+source = "git+https://github.com/Byron/gitoxide?rev=281fda06#281fda06a89b1d38cf6afeda23cf80a68486140b"
 dependencies = [
  "gix-actor",
  "gix-date",
- "gix-features",
- "gix-fs",
- "gix-hash",
+ "gix-features 0.36.1 (git+https://github.com/Byron/gitoxide?rev=281fda06)",
+ "gix-fs 0.8.1 (git+https://github.com/Byron/gitoxide?rev=281fda06)",
+ "gix-hash 0.13.2",
  "gix-lock",
  "gix-object",
  "gix-path",
- "gix-tempfile",
+ "gix-tempfile 11.0.1 (git+https://github.com/Byron/gitoxide?rev=281fda06)",
  "gix-validate",
  "memmap2",
  "serde",
@@ -1290,11 +1342,11 @@ dependencies = [
 
 [[package]]
 name = "gix-refspec"
-version = "0.19.0"
-source = "git+https://github.com/Byron/gitoxide?rev=2b80d842#2b80d8424196088d4ccc36914c87e320e4416ea1"
+version = "0.20.0"
+source = "git+https://github.com/Byron/gitoxide?rev=281fda06#281fda06a89b1d38cf6afeda23cf80a68486140b"
 dependencies = [
  "bstr",
- "gix-hash",
+ "gix-hash 0.13.2",
  "gix-revision",
  "gix-validate",
  "smallvec",
@@ -1303,28 +1355,28 @@ dependencies = [
 
 [[package]]
 name = "gix-revision"
-version = "0.23.0"
-source = "git+https://github.com/Byron/gitoxide?rev=2b80d842#2b80d8424196088d4ccc36914c87e320e4416ea1"
+version = "0.24.0"
+source = "git+https://github.com/Byron/gitoxide?rev=281fda06#281fda06a89b1d38cf6afeda23cf80a68486140b"
 dependencies = [
  "bstr",
  "gix-date",
- "gix-hash",
+ "gix-hash 0.13.2",
  "gix-hashtable",
  "gix-object",
  "gix-revwalk",
- "gix-trace",
+ "gix-trace 0.1.4 (git+https://github.com/Byron/gitoxide?rev=281fda06)",
  "serde",
  "thiserror",
 ]
 
 [[package]]
 name = "gix-revwalk"
-version = "0.9.0"
-source = "git+https://github.com/Byron/gitoxide?rev=2b80d842#2b80d8424196088d4ccc36914c87e320e4416ea1"
+version = "0.10.0"
+source = "git+https://github.com/Byron/gitoxide?rev=281fda06#281fda06a89b1d38cf6afeda23cf80a68486140b"
 dependencies = [
  "gix-commitgraph",
  "gix-date",
- "gix-hash",
+ "gix-hash 0.13.2",
  "gix-hashtable",
  "gix-object",
  "smallvec",
@@ -1333,8 +1385,8 @@ dependencies = [
 
 [[package]]
 name = "gix-sec"
-version = "0.10.0"
-source = "git+https://github.com/Byron/gitoxide?rev=2b80d842#2b80d8424196088d4ccc36914c87e320e4416ea1"
+version = "0.10.1"
+source = "git+https://github.com/Byron/gitoxide?rev=281fda06#281fda06a89b1d38cf6afeda23cf80a68486140b"
 dependencies = [
  "bitflags 2.4.1",
  "gix-path",
@@ -1345,15 +1397,15 @@ dependencies = [
 
 [[package]]
 name = "gix-status"
-version = "0.2.0"
-source = "git+https://github.com/Byron/gitoxide?rev=2b80d842#2b80d8424196088d4ccc36914c87e320e4416ea1"
+version = "0.3.0"
+source = "git+https://github.com/Byron/gitoxide?rev=281fda06#281fda06a89b1d38cf6afeda23cf80a68486140b"
 dependencies = [
  "bstr",
  "filetime",
- "gix-features",
+ "gix-features 0.36.1 (git+https://github.com/Byron/gitoxide?rev=281fda06)",
  "gix-filter",
- "gix-fs",
- "gix-hash",
+ "gix-fs 0.8.1 (git+https://github.com/Byron/gitoxide?rev=281fda06)",
+ "gix-hash 0.13.2",
  "gix-index",
  "gix-object",
  "gix-path",
@@ -1363,8 +1415,8 @@ dependencies = [
 
 [[package]]
 name = "gix-submodule"
-version = "0.5.0"
-source = "git+https://github.com/Byron/gitoxide?rev=2b80d842#2b80d8424196088d4ccc36914c87e320e4416ea1"
+version = "0.6.0"
+source = "git+https://github.com/Byron/gitoxide?rev=281fda06#281fda06a89b1d38cf6afeda23cf80a68486140b"
 dependencies = [
  "bstr",
  "gix-config",
@@ -1377,10 +1429,24 @@ dependencies = [
 
 [[package]]
 name = "gix-tempfile"
-version = "11.0.0"
-source = "git+https://github.com/Byron/gitoxide?rev=2b80d842#2b80d8424196088d4ccc36914c87e320e4416ea1"
+version = "11.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "388dd29114a86ec69b28d1e26d6d63a662300ecf61ab3f4cc578f7d7dc9e7e23"
 dependencies = [
- "gix-fs",
+ "dashmap",
+ "gix-fs 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc",
+ "once_cell",
+ "parking_lot",
+ "tempfile",
+]
+
+[[package]]
+name = "gix-tempfile"
+version = "11.0.1"
+source = "git+https://github.com/Byron/gitoxide?rev=281fda06#281fda06a89b1d38cf6afeda23cf80a68486140b"
+dependencies = [
+ "gix-fs 0.8.1 (git+https://github.com/Byron/gitoxide?rev=281fda06)",
  "libc",
  "once_cell",
  "parking_lot",
@@ -1391,19 +1457,25 @@ dependencies = [
 
 [[package]]
 name = "gix-trace"
-version = "0.1.3"
-source = "git+https://github.com/Byron/gitoxide?rev=2b80d842#2b80d8424196088d4ccc36914c87e320e4416ea1"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b686a35799b53a9825575ca3f06481d0a053a409c4d97ffcf5ddd67a8760b497"
+
+[[package]]
+name = "gix-trace"
+version = "0.1.4"
+source = "git+https://github.com/Byron/gitoxide?rev=281fda06#281fda06a89b1d38cf6afeda23cf80a68486140b"
 
 [[package]]
 name = "gix-transport"
-version = "0.38.0"
-source = "git+https://github.com/Byron/gitoxide?rev=2b80d842#2b80d8424196088d4ccc36914c87e320e4416ea1"
+version = "0.39.0"
+source = "git+https://github.com/Byron/gitoxide?rev=281fda06#281fda06a89b1d38cf6afeda23cf80a68486140b"
 dependencies = [
  "base64",
  "bstr",
  "gix-command",
  "gix-credentials",
- "gix-features",
+ "gix-features 0.36.1 (git+https://github.com/Byron/gitoxide?rev=281fda06)",
  "gix-packetline",
  "gix-quote",
  "gix-sec",
@@ -1415,12 +1487,12 @@ dependencies = [
 
 [[package]]
 name = "gix-traverse"
-version = "0.34.0"
-source = "git+https://github.com/Byron/gitoxide?rev=2b80d842#2b80d8424196088d4ccc36914c87e320e4416ea1"
+version = "0.35.0"
+source = "git+https://github.com/Byron/gitoxide?rev=281fda06#281fda06a89b1d38cf6afeda23cf80a68486140b"
 dependencies = [
  "gix-commitgraph",
  "gix-date",
- "gix-hash",
+ "gix-hash 0.13.2",
  "gix-hashtable",
  "gix-object",
  "gix-revwalk",
@@ -1430,11 +1502,11 @@ dependencies = [
 
 [[package]]
 name = "gix-url"
-version = "0.25.1"
-source = "git+https://github.com/Byron/gitoxide?rev=2b80d842#2b80d8424196088d4ccc36914c87e320e4416ea1"
+version = "0.25.2"
+source = "git+https://github.com/Byron/gitoxide?rev=281fda06#281fda06a89b1d38cf6afeda23cf80a68486140b"
 dependencies = [
  "bstr",
- "gix-features",
+ "gix-features 0.36.1 (git+https://github.com/Byron/gitoxide?rev=281fda06)",
  "gix-path",
  "home",
  "serde",
@@ -1444,16 +1516,16 @@ dependencies = [
 
 [[package]]
 name = "gix-utils"
-version = "0.1.5"
-source = "git+https://github.com/Byron/gitoxide?rev=2b80d842#2b80d8424196088d4ccc36914c87e320e4416ea1"
+version = "0.1.6"
+source = "git+https://github.com/Byron/gitoxide?rev=281fda06#281fda06a89b1d38cf6afeda23cf80a68486140b"
 dependencies = [
  "fastrand",
 ]
 
 [[package]]
 name = "gix-validate"
-version = "0.8.0"
-source = "git+https://github.com/Byron/gitoxide?rev=2b80d842#2b80d8424196088d4ccc36914c87e320e4416ea1"
+version = "0.8.1"
+source = "git+https://github.com/Byron/gitoxide?rev=281fda06#281fda06a89b1d38cf6afeda23cf80a68486140b"
 dependencies = [
  "bstr",
  "thiserror",
@@ -1461,15 +1533,15 @@ dependencies = [
 
 [[package]]
 name = "gix-worktree"
-version = "0.27.0"
-source = "git+https://github.com/Byron/gitoxide?rev=2b80d842#2b80d8424196088d4ccc36914c87e320e4416ea1"
+version = "0.28.0"
+source = "git+https://github.com/Byron/gitoxide?rev=281fda06#281fda06a89b1d38cf6afeda23cf80a68486140b"
 dependencies = [
  "bstr",
  "gix-attributes",
- "gix-features",
- "gix-fs",
+ "gix-features 0.36.1 (git+https://github.com/Byron/gitoxide?rev=281fda06)",
+ "gix-fs 0.8.1 (git+https://github.com/Byron/gitoxide?rev=281fda06)",
  "gix-glob",
- "gix-hash",
+ "gix-hash 0.13.2",
  "gix-ignore",
  "gix-index",
  "gix-object",
@@ -1479,15 +1551,15 @@ dependencies = [
 
 [[package]]
 name = "gix-worktree-state"
-version = "0.4.0"
-source = "git+https://github.com/Byron/gitoxide?rev=2b80d842#2b80d8424196088d4ccc36914c87e320e4416ea1"
+version = "0.5.0"
+source = "git+https://github.com/Byron/gitoxide?rev=281fda06#281fda06a89b1d38cf6afeda23cf80a68486140b"
 dependencies = [
  "bstr",
- "gix-features",
+ "gix-features 0.36.1 (git+https://github.com/Byron/gitoxide?rev=281fda06)",
  "gix-filter",
- "gix-fs",
+ "gix-fs 0.8.1 (git+https://github.com/Byron/gitoxide?rev=281fda06)",
  "gix-glob",
- "gix-hash",
+ "gix-hash 0.13.2",
  "gix-index",
  "gix-object",
  "gix-path",
@@ -1498,14 +1570,14 @@ dependencies = [
 
 [[package]]
 name = "gix-worktree-stream"
-version = "0.6.0"
-source = "git+https://github.com/Byron/gitoxide?rev=2b80d842#2b80d8424196088d4ccc36914c87e320e4416ea1"
+version = "0.7.0"
+source = "git+https://github.com/Byron/gitoxide?rev=281fda06#281fda06a89b1d38cf6afeda23cf80a68486140b"
 dependencies = [
  "gix-attributes",
- "gix-features",
+ "gix-features 0.36.1 (git+https://github.com/Byron/gitoxide?rev=281fda06)",
  "gix-filter",
- "gix-fs",
- "gix-hash",
+ "gix-fs 0.8.1 (git+https://github.com/Byron/gitoxide?rev=281fda06)",
+ "gix-hash 0.13.2",
  "gix-object",
  "gix-path",
  "gix-traverse",
@@ -1901,9 +1973,9 @@ checksum = "f665ee40bc4a3c5590afb1e9677db74a508659dfd71e126420da8274909a0167"
 
 [[package]]
 name = "memmap2"
-version = "0.7.1"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f49388d20533534cd19360ad3d6a7dadc885944aa802ba3995040c5ec11288c6"
+checksum = "45fd3a57831bf88bc63f8cebc0cf956116276e97fef3966103e96416209f7c92"
 dependencies = [
  "libc",
 ]
@@ -2240,9 +2312,9 @@ dependencies = [
 
 [[package]]
 name = "prodash"
-version = "26.2.2"
+version = "27.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "794b5bf8e2d19b53dcdcec3e4bba628e20f5b6062503ba89281fa7037dd7bbcf"
+checksum = "7309f1ec8d18f40e3b874087c413ba69566bb7212e6d4cfdd25758e51cb0068d"
 dependencies = [
  "bytesize",
  "human_format",
@@ -3190,9 +3262,9 @@ checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "winnow"
-version = "0.5.19"
+version = "0.5.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "829846f3e3db426d4cee4510841b71a8e58aa2a76b1132579487ae430ccd9c7b"
+checksum = "9b5c3db89721d50d0e2a673f5043fc4722f76dcc352d7b1ab8b8288bed4ed2c5"
 dependencies = [
  "memchr",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2021"
 
 [dependencies]
 clap = { version = "4.1.4", features = ["derive"] }
-gix = { git = "https://github.com/Byron/gitoxide", rev = "2b80d842", features = ["default", "blocking-network-client", "blocking-http-transport-reqwest-native-tls", "serde"] }
+gix = { git = "https://github.com/Byron/gitoxide", rev = "281fda06", features = ["default", "blocking-network-client", "blocking-http-transport-reqwest-native-tls", "serde"] }
 humantime = "2.1.0"
 jwt-simple = "0.11.7"
 reqwest = { version = "0.11.20", default-features = false, features = ["blocking", "default-tls", "serde_json", "gzip", "deflate", "json"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2021"
 
 [dependencies]
 clap = { version = "4.1.4", features = ["derive"] }
-gix = { version = "0.55.2", features = ["default", "blocking-network-client", "blocking-http-transport-reqwest-native-tls", "serde"] }
+gix = { git = "https://github.com/Byron/gitoxide", rev = "2b80d842", features = ["default", "blocking-network-client", "blocking-http-transport-reqwest-native-tls", "serde"] }
 humantime = "2.1.0"
 jwt-simple = "0.11.7"
 reqwest = { version = "0.11.20", default-features = false, features = ["blocking", "default-tls", "serde_json", "gzip", "deflate", "json"] }

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ The plan forward, roughly in falling priority:
 - [x] changed task config should override state loaded from disk
 - [x] docker packaging
 - [ ] readme with design and deployment options
+- [ ] branch patterns allows a task to react to changes on many branches
 - [ ] intelligent gitconfig handling
 - [ ] allow git commands in workdir (but note that this means two tasks can no longer point to the same repo without additional changeas)
 - [ ] useful logging (log level, json)

--- a/README.md
+++ b/README.md
@@ -25,4 +25,4 @@ The plan forward, roughly in falling priority:
 - [ ] lock state so that many kitops instances can collaborate
 - [ ] support Amazon S3 as state store
 - [ ] support Azure Blob storage as state store
-- [ ] GitHub app for checking out private repo
+- [x] GitHub app for checking out private repo

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -54,6 +54,9 @@ pub enum GitOpsError {
     GitHubNetworkError(reqwest::Error),
     #[error("GitHub App is installed but does not have write permissions for commit statuses")]
     GitHubPermissionsError,
+    #[cfg(test)]
+    #[error("Test error")]
+    TestError,
 }
 
 impl GitOpsError {

--- a/src/opts.rs
+++ b/src/opts.rs
@@ -46,9 +46,9 @@ pub struct CliOptions {
     /// GitHub App private key file
     #[clap(long)]
     pub github_private_key_file: Option<PathBuf>,
-    /// Turn on updating GitHub commit status with this context (requires auth flags)
+    /// Turn on updating GitHub commit status updates with this context (requires auth flags)
     #[clap(long)]
-    pub github_context: Option<String>,
+    pub github_status_context: Option<String>,
     /// Check repo for changes at this interval (e.g. 1h, 30m, 10s)
     #[arg(long, value_parser = humantime::parse_duration)]
     pub interval: Option<Duration>,
@@ -106,7 +106,7 @@ fn into_task(mut config: GitTaskConfig, opts: &CliOptions) -> ScheduledTask<GitW
     }
     let mut work = GitWorkload::from_config(config, opts);
     if let Some(github) = github {
-        if github.notify_context.is_some() {
+        if github.status_context.is_some() {
             work.watch(github_watcher(slug.unwrap(), github));
         }
     }

--- a/src/task/github.rs
+++ b/src/task/github.rs
@@ -1,6 +1,11 @@
-use std::{fs::File, io::Read, path::PathBuf, time::Duration};
+use std::{
+    fs::File,
+    io::Read,
+    path::{Path, PathBuf},
+    time::Duration,
+};
 
-use gix::ObjectId;
+use gix::{ObjectId, Url};
 use jwt_simple::prelude::{Claims, RS256KeyPair, RSAKeyPairLike};
 use reqwest::{
     blocking::ClientBuilder,
@@ -9,44 +14,79 @@ use reqwest::{
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
-use crate::{errors::GitOpsError, opts::CliOptions, receiver::WorkloadEvent};
+use crate::{errors::GitOpsError, git::UrlProvider, opts::CliOptions, receiver::WorkloadEvent};
 
 #[derive(Clone, Deserialize)]
-pub struct GitHubNotifyConfig {
+pub struct GithubConfig {
     app_id: String,
     private_key_file: PathBuf,
-    repo_slug: String,
-    #[serde(default = "GitHubNotifyConfig::default_context")]
-    context: String,
+    notify_slug: Option<String>,
+    #[serde(default = "GithubConfig::default_context")]
+    notify_context: Option<String>,
 }
 
-impl GitHubNotifyConfig {
-    pub fn default_context() -> String {
-        "kitops".to_owned()
+impl GithubConfig {
+    pub fn default_context() -> Option<String> {
+        Some("kitops".to_owned())
     }
 }
 
-impl TryFrom<&CliOptions> for Option<GitHubNotifyConfig> {
+impl TryFrom<&CliOptions> for Option<GithubConfig> {
     type Error = GitOpsError;
 
     fn try_from(opts: &CliOptions) -> Result<Self, Self::Error> {
-        match (
-            &opts.github_app_id,
-            &opts.github_private_key_file,
-            &opts.github_repo_slug,
-            &opts.github_context,
-        ) {
-            (None, None, None, None) => Ok(None),
-            (Some(app_id), Some(private_key_file), Some(repo_slug), Some(context)) => {
-                Ok(Some(GitHubNotifyConfig {
-                    app_id: app_id.clone(),
-                    private_key_file: private_key_file.clone(),
-                    repo_slug: repo_slug.clone(),
-                    context: context.clone(),
-                }))
-            }
+        match (&opts.github_app_id, &opts.github_private_key_file) {
+            (None, None) => Ok(None),
+            (Some(app_id), Some(private_key_file)) => Ok(Some(GithubConfig {
+                app_id: app_id.clone(),
+                private_key_file: private_key_file.clone(),
+                notify_slug: opts.github_repo_slug.clone(),
+                notify_context: opts.github_context.clone(),
+            })),
             _ => Err(GitOpsError::InvalidNotifyConfig),
         }
+    }
+}
+
+#[derive(Clone)]
+pub struct GithubUrlProvider {
+    url: Url,
+    app_id: String,
+    private_key_file: PathBuf,
+}
+
+impl GithubUrlProvider {
+    pub fn new(url: Url, config: &GithubConfig) -> Self {
+        GithubUrlProvider {
+            url,
+            app_id: config.app_id.clone(),
+            private_key_file: config.private_key_file.clone(),
+        }
+    }
+}
+
+impl UrlProvider for GithubUrlProvider {
+    fn url(&self) -> &Url {
+        &self.url
+    }
+
+    fn auth_url(&self) -> Result<Url, GitOpsError> {
+        let repo_slug = self.url.path.to_string().replace(".git", "")[1..].to_owned();
+        let client = http_client();
+        let jwt_token = generate_jwt(&self.app_id, &self.private_key_file)?;
+        let installation_id = get_installation_id(&repo_slug, &client, &jwt_token)?;
+        let access_token = get_access_token(installation_id, &client, &jwt_token)?;
+        // TODO Newer version of gix-url has set_username/set_password
+        Ok(Url::from_parts(
+            self.url.scheme.clone(),
+            Some("x-access-token".to_owned()),
+            Some(access_token),
+            self.url.host().map(str::to_owned),
+            self.url.port,
+            self.url.path.clone(),
+            false,
+        )
+        .unwrap())
     }
 }
 
@@ -62,11 +102,17 @@ pub enum GitHubStatus {
     Error,
 }
 
-fn generate_jwt(config: &GitHubNotifyConfig) -> Result<String, GitOpsError> {
-    let claims = Claims::create(jwt_simple::prelude::Duration::from_secs(60))
-        .with_issuer(config.app_id.clone());
+fn http_client() -> reqwest::blocking::Client {
+    ClientBuilder::new()
+        .connect_timeout(Duration::from_secs(5))
+        .build()
+        .unwrap()
+}
+
+fn generate_jwt(app_id: &str, private_key_file: &Path) -> Result<String, GitOpsError> {
+    let claims = Claims::create(jwt_simple::prelude::Duration::from_secs(60)).with_issuer(app_id);
     let mut buf = String::with_capacity(1800);
-    File::open(&config.private_key_file)
+    File::open(private_key_file)
         .map_err(GitOpsError::GitHubMissingPrivateKeyFile)?
         .read_to_string(&mut buf)
         .map_err(GitOpsError::GitHubMissingPrivateKeyFile)?;
@@ -77,15 +123,12 @@ fn generate_jwt(config: &GitHubNotifyConfig) -> Result<String, GitOpsError> {
 }
 
 fn get_installation_id(
-    config: &GitHubNotifyConfig,
+    repo_slug: &str,
     client: &reqwest::blocking::Client,
     jwt_token: &String,
 ) -> Result<u64, GitOpsError> {
     // TODO Is this different if we are installed organization-wise?
-    let url = format!(
-        "https://api.github.com/repos/{}/installation",
-        config.repo_slug
-    );
+    let url = format!("https://api.github.com/repos/{}/installation", repo_slug);
     let res = client
         .get(&url)
         .header(ACCEPT, "application/vnd.github+json")
@@ -140,27 +183,26 @@ fn get_access_token(
 }
 
 pub fn update_commit_status(
-    config: &GitHubNotifyConfig,
+    config: &GithubConfig,
     sha: &ObjectId,
     status: GitHubStatus,
     message: &str,
 ) -> Result<(), GitOpsError> {
-    let client = ClientBuilder::new()
-        .connect_timeout(Duration::from_secs(5))
-        .build()
-        .unwrap();
-
-    let jwt_token = generate_jwt(config)?;
-    let installation_id = get_installation_id(config, &client, &jwt_token)?;
+    let config = config.clone();
+    let client = http_client();
+    let jwt_token = generate_jwt(&config.app_id, &config.private_key_file)?;
+    let installation_id =
+        get_installation_id(config.notify_slug.as_ref().unwrap(), &client, &jwt_token)?;
     let access_token = get_access_token(installation_id, &client, &jwt_token)?;
 
     let url = format!(
         "https://api.github.com/repos/{}/statuses/{}",
-        config.repo_slug, sha
+        config.notify_slug.unwrap(),
+        sha
     );
     let body = serde_json::json!({
         "state": status,
-        "context": config.context,
+        "context": config.notify_context.unwrap(),
         "description": message,
     });
     let res = client
@@ -183,13 +225,13 @@ pub fn update_commit_status(
 }
 
 pub fn github_watcher(
-    notify_config: GitHubNotifyConfig,
+    config: GithubConfig,
 ) -> impl Fn(WorkloadEvent) -> Result<(), GitOpsError> + Send + 'static {
     move |event| {
         match event {
             WorkloadEvent::Changes(name, prev_sha, new_sha) => {
                 update_commit_status(
-                    &notify_config,
+                    &config,
                     &new_sha,
                     GitHubStatus::Pending,
                     &format!("running {} [last success {}]", name, prev_sha),
@@ -197,7 +239,7 @@ pub fn github_watcher(
             }
             WorkloadEvent::Success(name, new_sha) => {
                 update_commit_status(
-                    &notify_config,
+                    &config,
                     &new_sha,
                     GitHubStatus::Success,
                     &format!("{} succeeded", name),
@@ -205,7 +247,7 @@ pub fn github_watcher(
             }
             WorkloadEvent::Failure(task, action, new_sha) => {
                 update_commit_status(
-                    &notify_config,
+                    &config,
                     &new_sha,
                     GitHubStatus::Failure,
                     &format!("{} failed on action {}", task, action),
@@ -213,7 +255,7 @@ pub fn github_watcher(
             }
             WorkloadEvent::Error(task, action, new_sha) => {
                 update_commit_status(
-                    &notify_config,
+                    &config,
                     &new_sha,
                     GitHubStatus::Error,
                     &format!("{} errored on action {}", task, action),

--- a/src/task/github.rs
+++ b/src/task/github.rs
@@ -21,7 +21,7 @@ pub struct GithubConfig {
     app_id: String,
     private_key_file: PathBuf,
     #[serde(default = "GithubConfig::default_context")]
-    pub notify_context: Option<String>,
+    pub status_context: Option<String>,
 }
 
 impl GithubConfig {
@@ -39,7 +39,7 @@ impl TryFrom<&CliOptions> for Option<GithubConfig> {
             (Some(app_id), Some(private_key_file)) => Ok(Some(GithubConfig {
                 app_id: app_id.clone(),
                 private_key_file: private_key_file.clone(),
-                notify_context: opts.github_context.clone(),
+                status_context: opts.github_status_context.clone(),
             })),
             _ => Err(GitOpsError::InvalidNotifyConfig),
         }
@@ -202,7 +202,7 @@ pub fn update_commit_status(
     );
     let body = serde_json::json!({
         "state": status,
-        "context": config.notify_context.unwrap(),
+        "context": config.status_context.unwrap(),
         "description": message,
     });
     let res = client

--- a/src/task/gixworkload.rs
+++ b/src/task/gixworkload.rs
@@ -30,7 +30,7 @@ impl GitWorkload {
         let repo_dir = opts
             .repo_dir
             .as_ref()
-            .map(|dir| dir.join(config.git.safe_url()))
+            .map(|dir| dir.join(config.git.url.safe_url()))
             .unwrap();
         GitWorkload {
             config,

--- a/src/task/mod.rs
+++ b/src/task/mod.rs
@@ -51,7 +51,7 @@ where
 pub struct GitTaskConfig {
     name: String,
     pub github: Option<github::GithubConfig>,
-    git: GitConfig,
+    pub git: GitConfig,
     actions: Vec<Action>,
     #[serde(
         default = "GitTaskConfig::default_interval",

--- a/src/task/mod.rs
+++ b/src/task/mod.rs
@@ -1,12 +1,18 @@
 use std::{
     path::PathBuf,
+    sync::Arc,
     time::{Duration, SystemTime},
 };
 
 use gix::{hash::Kind, ObjectId, Url};
 use serde::{Deserialize, Deserializer, Serialize};
 
-use crate::{actions::Action, errors::GitOpsError, git::GitConfig, opts::CliOptions};
+use crate::{
+    actions::Action,
+    errors::GitOpsError,
+    git::{GitConfig, UrlProvider},
+    opts::CliOptions,
+};
 
 pub mod github;
 pub mod gixworkload;
@@ -44,8 +50,8 @@ where
 #[derive(Clone, Deserialize)]
 pub struct GitTaskConfig {
     name: String,
+    pub github: Option<github::GithubConfig>,
     git: GitConfig,
-    pub notify: Option<github::GitHubNotifyConfig>,
     actions: Vec<Action>,
     #[serde(
         default = "GitTaskConfig::default_interval",
@@ -60,6 +66,15 @@ pub struct GitTaskConfig {
 }
 
 impl GitTaskConfig {
+    pub fn upgrade_url_provider<U, Q>(&mut self, upgrader: U)
+    where
+        U: FnOnce(&Arc<Box<dyn UrlProvider>>) -> Q,
+        Q: UrlProvider + 'static,
+    {
+        let new_provider = upgrader(&self.git.url);
+        self.git.url = Arc::new(Box::new(new_provider));
+    }
+
     pub fn add_action(&mut self, action: Action) {
         self.actions.push(action);
     }
@@ -73,8 +88,8 @@ impl TryFrom<&CliOptions> for GitTaskConfig {
         let action: Action = TryFrom::try_from(opts)?;
         Ok(Self {
             name: url.path.to_string(),
+            github: TryFrom::try_from(opts)?,
             git: TryFrom::try_from(opts)?,
-            notify: TryFrom::try_from(opts)?,
             actions: vec![action],
             interval: opts.interval.unwrap_or(Self::default_interval()),
             timeout: opts.timeout.unwrap_or(Self::default_timeout()),

--- a/src/testutils.rs
+++ b/src/testutils.rs
@@ -1,9 +1,15 @@
-use std::{path::PathBuf, sync::Arc, thread::sleep, time::Duration};
+use std::{
+    path::PathBuf,
+    sync::{Arc, Mutex},
+    thread::sleep,
+    time::Duration,
+};
 
-use gix::ObjectId;
+use gix::{ObjectId, Url};
 
 use crate::{
     errors::GitOpsError,
+    git::UrlProvider,
     task::{scheduled::ScheduledTask, Workload},
 };
 
@@ -17,6 +23,35 @@ impl<W: Workload + Clone + Send + 'static> ScheduledTask<W> {
     pub fn await_eligible(&self) {
         while !self.is_eligible() {
             sleep(Duration::from_millis(2));
+        }
+    }
+}
+
+pub struct TestUrl {
+    url: Url,
+    auth_url_error: Mutex<Option<GitOpsError>>,
+}
+
+impl TestUrl {
+    pub fn new(auth_url_error: Option<GitOpsError>) -> Self {
+        let url = gix::url::parse("https://example.com".into()).unwrap();
+        TestUrl {
+            url,
+            auth_url_error: Mutex::new(auth_url_error),
+        }
+    }
+}
+
+impl UrlProvider for TestUrl {
+    fn url(&self) -> &Url {
+        &self.url
+    }
+
+    fn auth_url(&self) -> Result<gix::Url, crate::errors::GitOpsError> {
+        if let Some(err) = self.auth_url_error.lock().unwrap().take() {
+            Err(err)
+        } else {
+            Ok(self.url().clone())
         }
     }
 }


### PR DESCRIPTION
This PR makes kitops automatically use configured github app credentials when cloning/fetching repositories. It also removes the `--github-repo-slug` option and instead calculates the repo to update commit statuses i from the repository URL. Also, commit status updates are now controlled by `--github-context`.